### PR TITLE
Remove condition on VDev using whole_disk

### DIFF
--- a/IML.DeviceAggregatorDaemon/src/LegacyParser.fs
+++ b/IML.DeviceAggregatorDaemon/src/LegacyParser.fs
@@ -94,10 +94,9 @@ let rec getDisks (vdev : VDev) =
         |> List.collect getDisks
     match vdev with
     | Disk { Disk = disk } ->
-        if disk.whole_disk = Some true then [ disk.path ]
-        else []
+        [ disk.path ]
     | File _ -> []
-    | RaidZ { RaidZ = { children = xs } } | Mirror { Mirror = { children = xs } } | RaidZ { RaidZ = { children = xs } } | Replacing { Replacing = { children = xs } } ->
+    | RaidZ { RaidZ = { children = xs } } | Mirror { Mirror = { children = xs } } | Replacing { Replacing = { children = xs } } ->
         collectChildDisks xs
     | Root { Root = { children = children; spares = spares; cache = cache } } ->
         [ children; spares; cache ] |> List.collect collectChildDisks


### PR DESCRIPTION
We currently predicate using `whole_disk` to include VDevs in the list
of matched devices.

However, when using /dev/mapper devices the whole_disk flag is not set
to true (see https://github.com/zfsonlinux/zfs/issues/2296).

Due to the unreliability of this method + how we are now accounting for
pool partitions, we should be able to remove this check.