### PR TITLE
Normalize VDev paths to devices

### DIFF
--- a/IML.CommonLibrary/src/Main.fs
+++ b/IML.CommonLibrary/src/Main.fs
@@ -19,9 +19,14 @@ module Map =
     Map.fold (fun acc k v -> Map.add k v acc) x y
   let filterKeys fn m =
     Map.filter (fun k _ -> fn k) m
-
   let mapValues fn m =
     Map.map (fun _ v -> fn v) m
+  let mapAll fn m =
+    Map.fold (fun m k t ->
+      let (k', t') = fn k t
+      Map.add k' t' m
+    ) Map.empty m
+
 
 [<RequireQualifiedAccess>]
 module Result =

--- a/IML.DeviceAggregatorDaemon/test/HandlersTest.fs
+++ b/IML.DeviceAggregatorDaemon/test/HandlersTest.fs
@@ -34,19 +34,9 @@ let heartbeatPayload =
     |> Message.encoder
     |> Some
 
-test "host has pool disks"
-<| fun () ->
-    toEqual
-        (matchPaths [ "/foo/bar"; "/foo/baz"; "/bar/baz" ]
-             [ "/foo/bar"; "/bar/baz" ], true) |> ignore
-test "host doesn't have pool disks"
-<| fun () ->
-    toEqual
-        (matchPaths [ "/foo/bar"; "/foo/baz"; "/bar/baz" ]
-             [ "/foo/bar"; "/bar/boz" ], true) |> ignore
-test "Discover no pools on host"
-<| fun () ->
-    discoverZpools "ffo.com" Map.empty Map.empty List.empty |> toMatchSnapshot
+test "Discover no pools on host" <| fun () ->
+    discoverZpools "ffo.com" Map.empty |> toMatchSnapshot
+
 testList "Server"
     [ let withSetup f (d : Jest.Bindings.DoneStatic) : unit =
           // bring up server to run test target handler

--- a/IML.Types/src/UeventTypes.fs
+++ b/IML.Types/src/UeventTypes.fs
@@ -130,6 +130,11 @@ module UEvent =
   let diskByPathRegex = "^/dev/disk/by-path/"
   let mapperPathRegex = "^/dev/mapper/"
 
+  let tryFindById (uevent : UEvent) =
+    Array.tryFind (fun (Path(x)) ->
+      Regex.Match(x, diskByIdRegex).Success
+    ) uevent.paths
+
   let private precedence = [|
     mapperPathRegex;
     diskByIdRegex;

--- a/IML.Types/test/fixtures.js
+++ b/IML.Types/test/fixtures.js
@@ -5039,7 +5039,7 @@ exports.scannerStateDatasets2 = {
               Disk: {
                 guid: 4304718208453908500,
                 state: 'ONLINE',
-                path: '/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_disk14-part1',
+                path: '/dev/sdb1',
                 dev_id: 'scsi-0QEMU_QEMU_HARDDISK_disk14-part1',
                 phys_path: 'virtio-pci-0000:00:05.0-scsi-0:0:0:13',
                 whole_disk: true,


### PR DESCRIPTION
We are currently doing a naive match to resolve zpools
to backing devices on other nodes. This makes the assumption
that the chosen `Uevent.path` is equivalent to the `VDev.path`
entered by the user when creating the pool, and does not hold
when the user enters a different path.

Normalize any given `VDev.path` to a by-id/* path, which should
be consistent between nodes on a particular tick.

In addition clean up the munging / parsing code and remove a
bunch of mutable state.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>