### PR TITLE
Filter pools / datasets that are empty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,6 @@ sudo: required
 language: generic
 services:
   - docker
-addons:
-  apt:
-    update: true
 jobs:
   include:
     - stage: test
@@ -25,22 +22,22 @@ jobs:
         - docker exec -it libzfs-dotnet bash -c 'cd /device-scanner/ && npm i --ignore-scripts && npm run restore && dotnet fable npm-coverage -- --ci'
         - codecov
     - stage: cd
-      if: branch !~ ^v\d+\.\d+\.\d+-.+$ AND type NOT IN (push, pull_request)
-      env: 'Continuous Deployment'
+      git:
+        depth: 999999
+      env: 'Type=Continuous Deployment'
       script:
         - openssl aes-256-cbc -K $encrypted_253525cedcf6_key -iv $encrypted_253525cedcf6_iv -in copr-mfl.enc -out copr-key -d
         - curl -O https://raw.githubusercontent.com/m3t/travis_wait/master/travis_wait
         - chmod 755 travis_wait
         - ./travis_wait "docker run -dit --name copr -v $(pwd):/builddir imlteam/dotnet-docker bash -c 'yum install -y rpmdevtools copr-cli git && cd /builddir && fake run build.fsx --release=$(git rev-list HEAD | wc -l)'"
-    - stage: deploy
-      if: branch =~ ^v\d+\.\d+\.\d+$
+    - stage: deploy-npm
+      env: Type='npm deploy'
       script:
         - docker run -dit --privileged --name libzfs-dotnet -v $(pwd):/device-scanner:rw -v /sys/fs/cgroup:/sys/fs/cgroup:ro intelhpdd/libzfs-dotnet
         - docker exec -i libzfs-dotnet bash -c 'cd /device-scanner/ && npm i && npm run restore && dotnet fable npm-build'
         - docker exec -i libzfs-dotnet bash -c "echo '//registry.npmjs.org/:_authToken=$NPM_TOKEN' > ~/.npmrc"
         - docker exec -i libzfs-dotnet bash -c "cd /device-scanner && npm pub"
-    - stage: deploy
-      if: branch =~ ^v\d+\.\d+\.\d+-.+$
+    - stage: deploy-copr
       env: Type='Copr deploy'
       before_deploy:
         - openssl aes-256-cbc -K $encrypted_253525cedcf6_key -iv $encrypted_253525cedcf6_iv -in copr-mfl.enc -out copr-key -d
@@ -52,3 +49,11 @@ jobs:
         script: ./travis_wait "docker run -dit --name copr -v $(pwd):/builddir imlteam/dotnet-docker bash -c 'yum install -y rpmdevtools copr-cli && cd /builddir && fake run build.fsx'"
         on:
           all_branches: true
+stages:
+  - test
+  - name: cd
+    if: branch = master AND type = push AND fork = false
+  - name: deploy-npm
+    if: branch =~ ^v\d+\.\d+\.\d+$
+  - name: deploy-copr
+    if: branch =~ ^v\d+\.\d+\.\d+-.+$

--- a/IML.DeviceAggregatorDaemon/src/Handlers.fs
+++ b/IML.DeviceAggregatorDaemon/src/Handlers.fs
@@ -53,7 +53,7 @@ let discoverZpools (host : string) (blockDevices : BlockDevices) =
           |> List.choose UEvent.tryFindById
           |> Set.ofList
 
-        Set.isSubset poolPaths hostPaths
+        not (Set.isEmpty poolPaths) && Set.isSubset poolPaths hostPaths
       )
     )
 
@@ -93,7 +93,7 @@ let parseSysBlock (host : string) (state : State) =
       |> Map.merge zfsdatasets'
       |> Map.merge zfspools
       |> Map.merge zfsdatasets
-      |> Map.mapAll (fun k v ->
+      |> Map.mapAll (fun _ v ->
         (v.block_device, LegacyDev.LegacyZFSDev v)
       )
 


### PR DESCRIPTION
In:

https://github.com/whamcloud/device-scanner/blob/3b8325409a33d125550037de02194e84ac3337b1/IML.DeviceAggregatorDaemon/src/Handlers.fs#L56

We check for `poolPaths` that are a subset of paths on a host. However we don't account for the fact that an empty set is a subset of all sets.

Fix this.