### PR TITLE
Make port configurable

### DIFF
--- a/IML.ScannerProxyDaemon/src/Config.fs
+++ b/IML.ScannerProxyDaemon/src/Config.fs
@@ -8,10 +8,16 @@ open Fable.Core.JsInterop
 open Fable.Import.Node
 open IML.CommonLibrary
 
+let private envUrl : string = !!Globals.``process``.env?IML_MANAGER_URL
+let private parts = url.parse envUrl
+
 let managerUrl : string =
-    !!Globals.``process``.env?IML_MANAGER_URL
-    |> Option.bind (fun x -> (url.parse x).hostname)
+    parts.hostname
     |> Option.expect "Did not find IML_MANAGER_URL with hostname"
+
+let port : string =
+  parts.port
+  |> Option.expect "Did not find IML_MANAGER_URL with port"
 
 let cert = fs.readFileSync !!Globals.``process``.env?IML_CERT_PATH :> obj
 let key = fs.readFileSync !!Globals.``process``.env?IML_PRIVATE_KEY :> obj

--- a/IML.ScannerProxyDaemon/src/Transmit.fs
+++ b/IML.ScannerProxyDaemon/src/Transmit.fs
@@ -12,7 +12,7 @@ open IML.Types.MessageTypes
 let private opts = createEmpty<Https.RequestOptions>
 
 opts.hostname <- Some Config.managerUrl
-opts.port <- Some 443
+opts.port <- Some !!Config.port
 opts.path <- Some "/iml-device-aggregator"
 opts.method <- Some Http.Methods.Post
 opts.rejectUnauthorized <- Some false


### PR DESCRIPTION
The port for scanner-proxy was hardcoded to 443.

We need it to be configurable according to the env.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>