### PR TITLE
Fixup units

### DIFF
--- a/IML.DeviceScannerDaemon/systemd-units/block-device-populator.service
+++ b/IML.DeviceScannerDaemon/systemd-units/block-device-populator.service
@@ -5,3 +5,6 @@ After=device-scanner.socket
 [Service]
 ExecStart=/usr/sbin/udevadm trigger --action=change --subsystem-match=block
 Type=oneshot
+
+[Install]
+WantedBy=device-scanner.target

--- a/IML.DeviceScannerDaemon/systemd-units/device-scanner.target
+++ b/IML.DeviceScannerDaemon/systemd-units/device-scanner.target
@@ -1,5 +1,19 @@
 [Unit]
 Description=Device Scanner Services
 
+Requires=device-scanner.socket
+After=device-scanner.socket
 Requires=block-device-populator.service
 Requires=zed-populator.service
+Requires=swap-emitter.timer
+Requires=mount-emitter.service
+Wants=scanner-proxy.path
+
+[Install]
+WantedBy=multi-user.target
+Also=device-scanner.socket
+Also=block-device-populator.service
+Also=zed-populator.service
+Also=swap-emitter.timer
+Also=mount-emitter.service
+Also=scanner-proxy.path

--- a/IML.DeviceScannerDaemon/systemd-units/zed-populator.service
+++ b/IML.DeviceScannerDaemon/systemd-units/zed-populator.service
@@ -5,3 +5,6 @@ After=device-scanner.socket
 [Service]
 Type=oneshot
 ExecStart=/bin/bash -c 'if /usr/sbin/udevadm info --path=/module/zfs; then echo \'{"ZedCommand":"Init"}\' | socat - UNIX-CONNECT:/var/run/device-scanner.sock; fi'
+
+[Install]
+WantedBy=device-scanner.target

--- a/IML.Listeners/MountEmitter/systemd-units/mount-emitter.service
+++ b/IML.Listeners/MountEmitter/systemd-units/mount-emitter.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=IML Mount Emitter
-PartOf=device-scanner.socket
+PartOf=device-scanner.target
 After=local-fs.target
 After=device-scanner.socket
 Requires=mount-populator.service
@@ -14,4 +14,4 @@ StandardOutput=journal
 StandardError=journal
 
 [Install]
-WantedBy=device-scanner.socket
+WantedBy=device-scanner.target

--- a/IML.Listeners/MountEmitter/systemd-units/swap-emitter.timer
+++ b/IML.Listeners/MountEmitter/systemd-units/swap-emitter.timer
@@ -1,6 +1,6 @@
 [Unit]
 Description=IML Swap Emitter Timer
-PartOf=device-scanner.socket
+PartOf=device-scanner.target
 After=local-fs.target
 After=device-scanner.socket
 
@@ -9,4 +9,4 @@ OnUnitActiveSec=60
 OnStartupSec=0
 
 [Install]
-WantedBy=device-scanner.socket
+WantedBy=device-scanner.target

--- a/IML.ScannerProxyDaemon/systemd-units/scanner-proxy.path
+++ b/IML.ScannerProxyDaemon/systemd-units/scanner-proxy.path
@@ -1,11 +1,10 @@
 [Unit]
 Description=IML Scanner Proxy Path
-PartOf=device-scanner.socket
-BindsTo=device-scanner.service
-After=device-scanner.service
+PartOf=device-scanner.target
+After=device-scanner.socket
 
 [Path]
 PathExists=/etc/iml/manager-url.conf
 
 [Install]
-WantedBy=device-scanner.socket
+WantedBy=device-scanner.target


### PR DESCRIPTION
Currently units in device-scanner have two groupings, one under
device-scanner.socket, and another under device-scanner.target.

This makes it more difficult than necessary to stop / disable
everything, as we should just be able to use the device-scanner.target
to do that.

Move dependencies so they all fall into the device-scanner.target.

In addition use `Also`, so dependendant units will be enabled disabled
as needed.