### PR TITLE
Switch println for log

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -289,7 +289,9 @@ name = "device-aggregator"
 version = "2.0.0"
 dependencies = [
  "device-types 0.1.0",
+ "env_logger 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "pretty_assertions 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/device-aggregator/Cargo.toml
+++ b/device-aggregator/Cargo.toml
@@ -5,6 +5,8 @@ authors = ["IML Team <iml@whamcloud.com>"]
 license = "MIT"
 
 [dependencies]
+log = "0.4"
+env_logger = "0.6"
 tokio = "0.1"
 futures = "0.1"
 warp = "0.1"


### PR DESCRIPTION
Use [log](https://docs.rs/log/0.4.6/log/), [env_logger](https://docs.rs/env_logger/0.6.0/env_logger/)
and warp logging in device-aggregator.

To enable debug mode pass `RUST_LOG=device_aggregator` to the process.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>