### PR TITLE
Add device-fns module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -310,6 +310,7 @@ dependencies = [
  "env_logger 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "im 12.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "iml-device-fns 0.1.0",
  "libzfs-types 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "pretty_assertions 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -633,6 +634,14 @@ dependencies = [
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "iml-device-fns"
+version = "0.1.0"
+dependencies = [
+ "im 12.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libzfs-types 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,2 @@
 [workspace]
-members = ['device-types', 'device-scanner-daemon', 'futures-failure', 'device-scanner-proxy', 'device-aggregator', 'uevent-listener', 'mount-emitter', 'device-scanner-zedlets', 'zed-enhancer']
+members = ['device-types', 'device-scanner-daemon', 'futures-failure', 'device-scanner-proxy', 'device-aggregator', 'uevent-listener', 'mount-emitter', 'device-scanner-zedlets', 'zed-enhancer', 'iml-device-fns']

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -214,6 +214,8 @@ Vagrant.configure('2') do |config|
       cargo package --no-verify --allow-dirty
       cd /vagrant/zed-enhancer
       cargo package --no-verify --allow-dirty
+      cd /vagrant/iml-device-fns
+      cargo package --no-verify --allow-dirty
       mkdir -p /tmp/_topdir/SOURCES
       mv -f /vagrant/target/package/*.crate /tmp/_topdir/SOURCES/
       cd /vagrant

--- a/device-scanner-daemon/Cargo.toml
+++ b/device-scanner-daemon/Cargo.toml
@@ -16,6 +16,7 @@ env_logger = "0.6"
 bytes = { version = "0.4", features = ["serde"] }
 im = { version = "12.0.0", features = ["serde"] }
 device-types = { path = "../device-types", version = "0.1.0" }
+iml-device-fns = { path = "../iml-device-fns", version = "0.1.0" }
 libzfs-types = "0.1.1"
 
 [dev-dependencies]

--- a/device-scanner-daemon/src/lib.rs
+++ b/device-scanner-daemon/src/lib.rs
@@ -10,6 +10,7 @@ extern crate im;
 extern crate bytes;
 extern crate device_types;
 extern crate futures;
+extern crate iml_device_fns;
 extern crate libzfs_types;
 extern crate serde;
 extern crate serde_json;

--- a/device-scanner-daemon/src/state.rs
+++ b/device-scanner-daemon/src/state.rs
@@ -25,7 +25,7 @@ use device_types::{
     uevent::UEvent,
     Command,
 };
-use iml_device_fns::get_vdev_paths;
+use iml_device_fns::{find_by_major_minor, format_major_minor, get_vdev_paths};
 
 use reducers::{mount::update_mount, udev::update_udev, zed::update_zed_events};
 
@@ -52,14 +52,6 @@ fn is_partition(x: &UEvent) -> bool {
 
 fn is_mdraid(x: &UEvent) -> bool {
     x.md_uuid.is_some()
-}
-
-fn format_major_minor(major: &str, minor: &str) -> String {
-    format!("{}:{}", major, minor)
-}
-
-fn find_by_major_minor(xs: &Vector<String>, major: &str, minor: &str) -> bool {
-    xs.contains(&format_major_minor(major, minor))
 }
 
 fn find_mount<'a>(xs: &HashSet<PathBuf>, ys: &'a HashSet<Mount>) -> Option<&'a Mount> {

--- a/device-types/src/lib.rs
+++ b/device-types/src/lib.rs
@@ -266,6 +266,7 @@ pub mod devices {
             minor: String,
             filesystem_type: Option<String>,
             paths: Paths,
+            parent_paths: Paths,
             mount_path: Option<PathBuf>,
             uuid: String,
             children: Children,
@@ -285,6 +286,7 @@ pub mod devices {
             name: String,
             uuid: String,
             size: i64,
+            major_minors: im::Vector<String>,
             children: Children,
         },
         LogicalVolume {

--- a/iml-device-fns/Cargo.toml
+++ b/iml-device-fns/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "iml-device-fns"
+version = "0.1.0"
+authors = ["IML Team <iml@whamcloud.com>"]
+
+[dependencies]
+im = "12.0.0"
+libzfs-types = "0.1.1"

--- a/iml-device-fns/src/lib.rs
+++ b/iml-device-fns/src/lib.rs
@@ -1,0 +1,29 @@
+extern crate im;
+extern crate libzfs_types;
+
+use std::path::PathBuf;
+
+use im::{hashset, HashSet};
+
+/// Traverses a VDev tree and returns back it's paths
+pub fn get_vdev_paths(vdev: libzfs_types::VDev) -> HashSet<PathBuf> {
+    match vdev {
+        libzfs_types::VDev::Disk { path, .. } => hashset![path],
+        libzfs_types::VDev::File { .. } => hashset![],
+        libzfs_types::VDev::Mirror { children, .. }
+        | libzfs_types::VDev::RaidZ { children, .. }
+        | libzfs_types::VDev::Replacing { children, .. } => {
+            children.into_iter().flat_map(get_vdev_paths).collect()
+        }
+        libzfs_types::VDev::Root {
+            children,
+            spares,
+            cache,
+            ..
+        } => vec![children, spares, cache]
+            .into_iter()
+            .flatten()
+            .flat_map(get_vdev_paths)
+            .collect(),
+    }
+}

--- a/iml-device-fns/src/lib.rs
+++ b/iml-device-fns/src/lib.rs
@@ -27,3 +27,11 @@ pub fn get_vdev_paths(vdev: libzfs_types::VDev) -> HashSet<PathBuf> {
             .collect(),
     }
 }
+
+pub fn format_major_minor(major: &str, minor: &str) -> String {
+    format!("{}:{}", major, minor)
+}
+
+pub fn find_by_major_minor(xs: &im::Vector<String>, major: &str, minor: &str) -> bool {
+    xs.contains(&format_major_minor(major, minor))
+}

--- a/iml-device-scanner.spec
+++ b/iml-device-scanner.spec
@@ -1,6 +1,7 @@
 %define     base_name device-scanner
 %define     device_types device-types-0.1.0
 %define     futures_failure futures-failure-0.1.0
+%define	    iml_device_fns iml-device-fns-0.1.0
 
 Name:       iml-%{base_name}
 Version:    2.0.0
@@ -18,6 +19,7 @@ Source5:    device-scanner-zedlets-0.1.0.crate
 Source6:    zed-enhancer-0.1.0.crate
 Source7:    %{device_types}.crate
 Source8:    %{futures_failure}.crate
+Source9:    %{iml_device_fns}.create
 
 %{?systemd_requires}
 BuildRequires: systemd
@@ -55,6 +57,8 @@ scanner instances.
 
 
 %prep
+%setup -T -D -b 9 -n %{iml_device_fns}
+
 %setup -T -D -b 8 -n %{futures_failure}
 
 %setup -T -D -b 7 -n %{device_types}
@@ -79,6 +83,7 @@ cat << EOF > ../patch.txt
 [patch.crates-io]
 device-types = { path = "../%{device_types}" }
 futures-failure = { path = "../%{futures_failure}" }
+iml-device-fns = { path = "../%{iml_device_fns}" }
 EOF
 
 cat ../patch.txt >> Cargo.toml

--- a/iml-device-scanner.spec
+++ b/iml-device-scanner.spec
@@ -19,7 +19,7 @@ Source5:    device-scanner-zedlets-0.1.0.crate
 Source6:    zed-enhancer-0.1.0.crate
 Source7:    %{device_types}.crate
 Source8:    %{futures_failure}.crate
-Source9:    %{iml_device_fns}.create
+Source9:    %{iml_device_fns}.crate
 
 %{?systemd_requires}
 BuildRequires: systemd


### PR DESCRIPTION
There are some fns that are useful on both the device-scanner and
device-aggregator.

Add a new module to reuse the code.

In addition, add parent device refs to VGs and MDRaid
so we don't need to traverse the tree to get all parents.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>