### PR TITLE
Use OrdSet instead of HashSet

### DIFF
--- a/device-scanner-daemon/src/reducers/udev.rs
+++ b/device-scanner-daemon/src/reducers/udev.rs
@@ -16,7 +16,7 @@ pub fn update_udev(uevents: &state::UEvents, cmd: UdevCommand) -> state::UEvents
 mod tests {
     use super::*;
     use device_types::{udev::UdevCommand, uevent::UEvent};
-    use im::{hashmap, hashset, vector};
+    use im::{hashmap, ordset, vector};
     use std::path::PathBuf;
 
     fn create_path_buf(s: &str) -> PathBuf {
@@ -32,7 +32,7 @@ mod tests {
             major: "253".to_string(),
             minor: "20".to_string(),
             seqnum: 3547,
-            paths: hashset![
+            paths: ordset![
                 create_path_buf(
                     "/dev/disk/by-id/dm-uuid-part1-mpath-3600140550e41a841db244a992c31e7df"
                 ),
@@ -64,7 +64,7 @@ mod tests {
             is_mpath: None,
             dm_slave_mms: vector!["253:13".to_string()],
             dm_vg_size: Some(0),
-            md_devs: hashset![],
+            md_devs: ordset![],
             dm_multipath_devpath: None,
             dm_name: Some("mpathd1".to_string()),
             dm_lv_name: None,

--- a/device-scanner-daemon/src/reducers/zed.rs
+++ b/device-scanner-daemon/src/reducers/zed.rs
@@ -105,7 +105,7 @@ pub fn update_zed_events(
                     .ok_or_else(|| Error::LibZfsError(libzfs_types::LibZfsError::ZfsNotFound(name)))
             }
 
-            let mut pool = take_pool(&mut zed_events, guid)?;
+            let pool = take_pool(&mut zed_events, guid)?;
             let mut dataset = get_dataset_in_pool(pool, name)?;
 
             dataset.props = update_prop(&key, &value, dataset.props);

--- a/device-types/src/lib.rs
+++ b/device-types/src/lib.rs
@@ -103,7 +103,7 @@ pub mod udev {
 }
 
 pub mod uevent {
-    use im::{HashSet, Vector};
+    use im::{OrdSet, Vector};
     use std::path::PathBuf;
 
     #[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
@@ -112,7 +112,7 @@ pub mod uevent {
         pub major: String,
         pub minor: String,
         pub seqnum: i64,
-        pub paths: HashSet<PathBuf>,
+        pub paths: OrdSet<PathBuf>,
         pub devname: PathBuf,
         pub devpath: PathBuf,
         pub devtype: String,
@@ -133,7 +133,7 @@ pub mod uevent {
         pub is_mpath: Option<bool>,
         pub dm_slave_mms: Vector<String>,
         pub dm_vg_size: Option<i64>,
-        pub md_devs: HashSet<PathBuf>,
+        pub md_devs: OrdSet<PathBuf>,
         pub dm_multipath_devpath: Option<bool>,
         pub dm_name: Option<String>,
         pub dm_lv_name: Option<String>,
@@ -226,12 +226,12 @@ pub enum Command {
 
 pub mod devices {
     use crate::mount;
-    use im::HashSet;
+    use im::{HashSet, OrdSet};
     use libzfs_types;
     use std::path::PathBuf;
 
     type Children = HashSet<Device>;
-    type Paths = HashSet<PathBuf>;
+    type Paths = OrdSet<PathBuf>;
 
     #[derive(Debug, PartialEq, Eq, Serialize, Hash, Deserialize, Clone)]
     pub enum Device {

--- a/uevent-listener/src/main.rs
+++ b/uevent-listener/src/main.rs
@@ -7,7 +7,7 @@
 extern crate pretty_assertions;
 
 use device_types::{udev::UdevCommand, uevent::UEvent, Command};
-use im::{HashSet, Vector};
+use im::{OrdSet, Vector};
 use std::{
     env, io::prelude::*, os::unix::net::UnixStream, path::PathBuf, process::exit, string::ToString,
 };
@@ -27,12 +27,12 @@ fn split_space(x: &str) -> Vector<String> {
         .collect()
 }
 
-fn get_paths() -> HashSet<PathBuf> {
+fn get_paths() -> OrdSet<PathBuf> {
     let devlinks = env::var("DEVLINKS").unwrap_or_else(|_| "".to_string());
 
     let devname = required_field("DEVNAME");
 
-    let mut xs: HashSet<PathBuf> = split_space(&devlinks)
+    let mut xs: OrdSet<PathBuf> = split_space(&devlinks)
         .iter()
         .map(|x| {
             let mut p = PathBuf::new();
@@ -92,7 +92,7 @@ fn create_pathbuf(contents: &str) -> PathBuf {
     p
 }
 
-fn md_devs<I>(iter: I) -> HashSet<PathBuf>
+fn md_devs<I>(iter: I) -> OrdSet<PathBuf>
 where
     I: Iterator<Item = (String, String)>,
 {
@@ -175,7 +175,7 @@ fn main() {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use im::hashset;
+    use im::ordset;
 
     #[test]
     fn test_lvm_uuids() {
@@ -224,7 +224,7 @@ mod tests {
 
         assert_eq!(
             result,
-            hashset![create_pathbuf("/dev/sda"), create_pathbuf("/dev/sdd")]
+            ordset![create_pathbuf("/dev/sda"), create_pathbuf("/dev/sdd")]
         );
     }
 }


### PR DESCRIPTION
Switch to using an OrdSet so the output of lists
is consistent between ticks.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>