### PR TITLE
Update device-aggregator socket

### DIFF
--- a/IML.DeviceAggregatorDaemon/systemd-units/device-aggregator.socket
+++ b/IML.DeviceAggregatorDaemon/systemd-units/device-aggregator.socket
@@ -7,4 +7,4 @@ ListenStream=/var/run/device-aggregator.sock
 RemoveOnStop=true
 
 [Install]
-WantedBy=sockets.target
+WantedBy=iml-manager.target


### PR DESCRIPTION
The device aggregator socket needs to specify that it is wanted by iml-manager.target and not sockets.target. This is
currently causing an ordering issue with systemd.

Signed-off-by: Will Johnson <wjohnson@whamcloud.com>