### PR TITLE
Split Device enum

### DIFF
--- a/device-types/src/devices.rs
+++ b/device-types/src/devices.rs
@@ -1,0 +1,131 @@
+// Copyright (c) 2019 DDN. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+use crate::{mount, DevicePath};
+use im::{hashset, HashSet, OrdSet};
+use libzfs_types;
+use std::path::PathBuf;
+
+type Children = HashSet<Device>;
+type Paths = OrdSet<DevicePath>;
+
+#[derive(Debug, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize, Clone)]
+pub struct Root {
+    pub children: Children,
+}
+
+impl Default for Root {
+    fn default() -> Self {
+        Self {
+            children: hashset![],
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize, Clone)]
+pub struct ScsiDevice {
+    pub serial: String,
+    pub scsi80: Option<String>,
+    pub major: String,
+    pub minor: String,
+    pub devpath: PathBuf,
+    pub size: i64,
+    pub filesystem_type: Option<String>,
+    pub paths: Paths,
+    pub mount: Option<mount::Mount>,
+    pub children: Children,
+}
+
+#[derive(Debug, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize, Clone)]
+pub struct Partition {
+    pub partition_number: i64,
+    pub size: i64,
+    pub major: String,
+    pub minor: String,
+    pub devpath: PathBuf,
+    pub filesystem_type: Option<String>,
+    pub paths: Paths,
+    pub mount: Option<mount::Mount>,
+    pub children: Children,
+}
+
+#[derive(Debug, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize, Clone)]
+pub struct MdRaid {
+    pub size: i64,
+    pub major: String,
+    pub minor: String,
+    pub filesystem_type: Option<String>,
+    pub paths: Paths,
+    pub mount: Option<mount::Mount>,
+    pub uuid: String,
+    pub children: Children,
+}
+
+#[derive(Debug, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize, Clone)]
+pub struct Mpath {
+    pub devpath: PathBuf,
+    pub serial: String,
+    pub size: i64,
+    pub major: String,
+    pub minor: String,
+    pub filesystem_type: Option<String>,
+    pub paths: Paths,
+    pub children: Children,
+    pub mount: Option<mount::Mount>,
+}
+
+#[derive(Debug, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize, Clone)]
+pub struct VolumeGroup {
+    pub name: String,
+    pub uuid: String,
+    pub size: i64,
+    pub children: Children,
+}
+
+#[derive(Debug, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize, Clone)]
+pub struct LogicalVolume {
+    pub name: String,
+    pub uuid: String,
+    pub major: String,
+    pub minor: String,
+    pub size: i64,
+    pub children: Children,
+    pub devpath: PathBuf,
+    pub paths: Paths,
+    pub filesystem_type: Option<String>,
+    pub mount: Option<mount::Mount>,
+}
+
+#[derive(Debug, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize, Clone)]
+pub struct Zpool {
+    pub guid: u64,
+    pub name: String,
+    pub health: String,
+    pub state: String,
+    pub size: u64,
+    pub vdev: libzfs_types::VDev,
+    pub props: Vec<libzfs_types::ZProp>,
+    pub children: Children,
+}
+
+#[derive(Debug, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize, Clone)]
+pub struct Dataset {
+    pub guid: String,
+    pub name: String,
+    pub kind: String,
+    pub props: Vec<libzfs_types::ZProp>,
+}
+
+#[derive(Debug, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize, Clone)]
+pub enum Device {
+    Root(Root),
+    ScsiDevice(ScsiDevice),
+    Partition(Partition),
+    MdRaid(MdRaid),
+    Mpath(Mpath),
+    VolumeGroup(VolumeGroup),
+    LogicalVolume(LogicalVolume),
+    Zpool(Zpool),
+    Dataset(Dataset),
+}

--- a/device-types/src/lib.rs
+++ b/device-types/src/lib.rs
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
+pub mod devices;
 pub mod udev;
 pub mod uevent;
 
@@ -234,101 +235,6 @@ pub enum Command {
     PoolCommand(zed::PoolCommand),
     UdevCommand(udev::UdevCommand),
     MountCommand(mount::MountCommand),
-}
-
-pub mod devices {
-    use crate::{mount, DevicePath};
-    use im::{HashSet, OrdSet};
-    use libzfs_types;
-    use std::path::PathBuf;
-
-    type Children = HashSet<Device>;
-    type Paths = OrdSet<DevicePath>;
-
-    #[derive(Debug, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize, Clone)]
-    pub enum Device {
-        Root {
-            children: Children,
-        },
-        ScsiDevice {
-            serial: String,
-            scsi80: Option<String>,
-            major: String,
-            minor: String,
-            devpath: PathBuf,
-            size: i64,
-            filesystem_type: Option<String>,
-            paths: Paths,
-            mount: Option<mount::Mount>,
-            children: Children,
-        },
-        Partition {
-            partition_number: i64,
-            size: i64,
-            major: String,
-            minor: String,
-            devpath: PathBuf,
-            filesystem_type: Option<String>,
-            paths: Paths,
-            mount: Option<mount::Mount>,
-            children: Children,
-        },
-        MdRaid {
-            size: i64,
-            major: String,
-            minor: String,
-            filesystem_type: Option<String>,
-            paths: Paths,
-            mount: Option<mount::Mount>,
-            uuid: String,
-            children: Children,
-        },
-        Mpath {
-            devpath: PathBuf,
-            serial: String,
-            size: i64,
-            major: String,
-            minor: String,
-            filesystem_type: Option<String>,
-            paths: Paths,
-            children: Children,
-            mount: Option<mount::Mount>,
-        },
-        VolumeGroup {
-            name: String,
-            uuid: String,
-            size: i64,
-            children: Children,
-        },
-        LogicalVolume {
-            name: String,
-            uuid: String,
-            major: String,
-            minor: String,
-            size: i64,
-            children: Children,
-            devpath: PathBuf,
-            paths: Paths,
-            filesystem_type: Option<String>,
-            mount: Option<mount::Mount>,
-        },
-        Zpool {
-            guid: u64,
-            name: String,
-            health: String,
-            state: String,
-            size: u64,
-            vdev: libzfs_types::VDev,
-            props: Vec<libzfs_types::ZProp>,
-            children: Children,
-        },
-        Dataset {
-            guid: String,
-            name: String,
-            kind: String,
-            props: Vec<libzfs_types::ZProp>,
-        },
-    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Split the Device enum into separate structs that are wrapped
by the Device enum.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>