### PR TITLE
Add mounts to ZPool and Dataset structs

### DIFF
--- a/device-types/src/devices.rs
+++ b/device-types/src/devices.rs
@@ -109,6 +109,7 @@ pub struct Zpool {
     pub vdev: libzfs_types::VDev,
     pub props: Vec<libzfs_types::ZProp>,
     pub children: Children,
+    pub mount: Option<mount::Mount>,
 }
 
 #[derive(Debug, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize, Clone)]
@@ -117,6 +118,7 @@ pub struct Dataset {
     pub name: String,
     pub kind: String,
     pub props: Vec<libzfs_types::ZProp>,
+    pub mount: Option<mount::Mount>,
 }
 
 #[derive(Debug, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize, Clone)]

--- a/device-types/src/lib.rs
+++ b/device-types/src/lib.rs
@@ -21,8 +21,8 @@ use std::{
 #[serde(transparent)]
 pub struct DevicePath(pub PathBuf);
 
-impl From<&str> for DevicePath {
-    fn from(s: &str) -> DevicePath {
+impl<S: Into<PathBuf>> From<S> for DevicePath {
+    fn from(s: S) -> DevicePath {
         DevicePath(s.into())
     }
 }


### PR DESCRIPTION
Add the mounts we know to the `ZPool` and `Dataset` structs.

This will allow consumers to see if anything is currently mounted under
a pool or dataset.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>