### PR TITLE
Add GetMounts cmd

### DIFF
--- a/device-scanner-daemon/src/main.rs
+++ b/device-scanner-daemon/src/main.rs
@@ -61,6 +61,15 @@ fn processor(
 
                 Ok(Some(connection))
             }
+            Some((Command::GetMounts, socket)) => {
+                let connection = connections::Connection::new(socket);
+
+                message_tx
+                    .clone()
+                    .unbounded_send((Command::GetMounts, connection.tx.clone()))?;
+
+                Ok(Some(connection))
+            }
             Some((cmd, socket)) => {
                 socket.shutdown(Shutdown::Both)?;
 

--- a/device-scanner-daemon/src/state.rs
+++ b/device-scanner-daemon/src/state.rs
@@ -524,6 +524,23 @@ pub fn handler() -> (
              }: State,
              (cmd, connections_tx): (Command, connections::Tx)|
              -> Result<State> {
+                if let Command::GetMounts = cmd {
+                    let v = serde_json::to_string(&local_mounts)?;
+                    let b = bytes::BytesMut::from(v + "\n");
+                    let b = b.freeze();
+
+                    connections_tx.unbounded_send(b.clone()).is_ok();
+
+                    return Ok(State {
+                        conns,
+                        state: state::State {
+                            uevents,
+                            local_mounts,
+                            zed_events,
+                        },
+                    });
+                }
+
                 conns.push(connections_tx);
 
                 let (mut uevents, local_mounts, zed_events) = match cmd {

--- a/device-types/src/lib.rs
+++ b/device-types/src/lib.rs
@@ -266,6 +266,7 @@ pub mod zed {
 #[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
 pub enum Command {
     Stream,
+    GetMounts,
     PoolCommand(zed::PoolCommand),
     UdevCommand(udev::UdevCommand),
     MountCommand(mount::MountCommand),


### PR DESCRIPTION
Add a GetMounts cmd so the IML agent can reference device mounts as it
did previously.

This is particularly useful for lustre client mounts, which are not
associated with a device.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>