### PR TITLE
Filter out `tmp/mntXXXXXX` from device-aggregator output

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ jobs:
         - docker exec -i libzfs bash -c 'cd /device-scanner && cargo test'
     - stage: test
       name: "Format Check"
-      rust: 1.34.2
+      rust: 1.35.0
       before_script:
         - rustup component add rustfmt
       script:
@@ -25,7 +25,7 @@ jobs:
         - ((`find _topdir/RPMS -name *.rpm | wc -l` > 0))
     - stage: test
       name: "Linting Check"
-      rust: 1.34.2
+      rust: 1.35.0
       script:
         - docker run -d -it --name libzfs -v $(pwd):/device-scanner:rw imlteam/zfs
         - docker exec -i libzfs bash -c 'yum install -y openssl-devel clippy'

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,9 @@ jobs:
   include:
     - stage: test
       name: "Unit Tests"
-      language: generic
+      rust: 1.35.0
       script:
-        - docker run -d -it --name libzfs -v $(pwd):/device-scanner:rw imlteam/zfs
-        - docker exec -i libzfs bash -c 'yum install -y openssl-devel cargo'
-        - docker exec -i libzfs bash -c 'cd /device-scanner && cargo test'
+        - cargo test --exclude zed-enhancer --all
     - stage: test
       name: "Format Check"
       rust: 1.35.0
@@ -19,13 +17,14 @@ jobs:
         - cargo fmt --all -- --check
     - stage: test
       name: "copr build test"
+      language: generic
       script:
         - export SPEC=iml-device-scanner.spec
         - docker run -it -e SPEC="$SPEC" -e LOCAL_ONLY="True" -v $(pwd):/build:rw imlteam/copr-zfs
         - ((`find _topdir/RPMS -name *.rpm | wc -l` > 0))
     - stage: test
       name: "Linting Check"
-      rust: 1.35.0
+      language: generic
       script:
         - docker run -d -it --name libzfs -v $(pwd):/device-scanner:rw imlteam/zfs
         - docker exec -i libzfs bash -c 'yum install -y openssl-devel clippy'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,15 +36,15 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "0.1.2"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "backtrace"
-version = "0.3.20"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "autocfg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "autocfg 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "backtrace-sys 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -156,8 +156,8 @@ name = "chrono"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "num-integer 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-integer 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -431,7 +431,7 @@ name = "failure"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "backtrace 0.3.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "backtrace 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -840,7 +840,7 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.6.17"
+version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -862,7 +862,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
- "mio 0.6.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio 0.6.18 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -933,19 +933,19 @@ dependencies = [
 
 [[package]]
 name = "num-integer"
-version = "0.1.40"
+version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "autocfg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "autocfg 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "num-traits"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "autocfg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "autocfg 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -994,7 +994,7 @@ name = "openssl-sys"
 version = "0.9.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "autocfg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "autocfg 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "cc 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1217,7 +1217,7 @@ name = "rand"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "autocfg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "autocfg 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1235,7 +1235,7 @@ name = "rand_chacha"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "autocfg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "autocfg 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1296,7 +1296,7 @@ name = "rand_pcg"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "autocfg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "autocfg 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1634,7 +1634,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "mio 0.6.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio 0.6.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-current-thread 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1696,7 +1696,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
- "mio 0.6.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio 0.6.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-reactor 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1739,7 +1739,7 @@ dependencies = [
  "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "mio 0.6.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio 0.6.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1765,7 +1765,7 @@ dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "mio 0.6.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio 0.6.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-reactor 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1823,7 +1823,7 @@ dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "mio 0.6.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio 0.6.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-reactor 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1839,7 +1839,7 @@ dependencies = [
  "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "mio 0.6.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio 0.6.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio-uds 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2109,8 +2109,8 @@ dependencies = [
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 "checksum arrayvec 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "92c7fb76bc8826a8b33b4ee5bb07a247a81e76764ab4d55e8f73e3a4d8808c71"
 "checksum atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "9a7d5b8723950951411ee34d271d99dddcc2035a16ab25310ea2c8cfd4369652"
-"checksum autocfg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a6d640bee2da49f60a4068a7fae53acde8982514ab7bae8b8cea9e88cbcfd799"
-"checksum backtrace 0.3.20 (registry+https://github.com/rust-lang/crates.io-index)" = "45934a579eff9fd0ff637ac376a4bd134f47f8fc603f0b211d696b54d61e35f1"
+"checksum autocfg 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "0e49efa51329a5fd37e7c79db4621af617cd4e3e5bc224939808d076077077bf"
+"checksum backtrace 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "8ca8a0a1f68b5d04b8d006c726d16e38455fc8886c51fff7c2e6df32333378e2"
 "checksum backtrace-sys 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)" = "797c830ac25ccc92a7f8a7b9862bde440715531514594a6154e3d4a54dd769b6"
 "checksum base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
 "checksum bindgen 0.43.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6d52d263eacd15d26cbcf215d254b410bd58212aaa2d3c453a04b2d3b3adcf41"
@@ -2191,15 +2191,15 @@ dependencies = [
 "checksum memoffset 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0f9dc261e2b62d7a622bf416ea3c5245cdd5d9a7fcc428c0d06804dfce1775b3"
 "checksum mime 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)" = "3e27ca21f40a310bd06d9031785f4801710d566c184a6e15bad4f1d9b65f9425"
 "checksum mime_guess 2.0.0-alpha.6 (registry+https://github.com/rust-lang/crates.io-index)" = "30de2e4613efcba1ec63d8133f344076952090c122992a903359be5a4f99c3ed"
-"checksum mio 0.6.17 (registry+https://github.com/rust-lang/crates.io-index)" = "049ba5ca2b63e837adeee724aa9e36b408ed593529dcc802aa96ca14bd329bdf"
+"checksum mio 0.6.18 (registry+https://github.com/rust-lang/crates.io-index)" = "9fbe95ae9216d99c944a1afa429fef2a2ed012b65b0840de5047a86a82969502"
 "checksum mio-uds 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)" = "966257a94e196b11bb43aca423754d87429960a768de9414f3691d6957abf125"
 "checksum miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
 "checksum native-tls 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "4b2df1a4c22fd44a62147fd8f13dd0f95c9d8ca7b2610299b2a2f9cf8964274e"
 "checksum net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)" = "42550d9fb7b6684a6d404d9fa7250c2eb2646df731d1c06afc06dcee9e1bcf88"
 "checksum nodrop 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "2f9667ddcc6cc8a43afc9b7917599d7216aa09c463919ea32c59ed6cac8bc945"
 "checksum nom 4.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2ad2a91a8e869eeb30b9cb3119ae87773a8f4ae617f41b1eb9c154b2905f7bd6"
-"checksum num-integer 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "8b8af8caa3184078cd419b430ff93684cb13937970fcb7639f728992f33ce674"
-"checksum num-traits 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "d9c79c952a4a139f44a0fe205c4ee66ce239c0e6ce72cd935f5f7e2f717549dd"
+"checksum num-integer 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)" = "b85e541ef8255f6cf42bbfe4ef361305c6c135d10919ecc26126c4e5ae94bc09"
+"checksum num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "6ba9a427cfca2be13aa6f6403b0b7e7368fe982bfa16fccc450ce74c46cd9b32"
 "checksum num_cpus 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1a23f0ed30a54abaa0c7e83b1d2d87ada7c3c23078d1d87815af3e3b6385fbba"
 "checksum numtoa 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b8f8bdf33df195859076e54ab11ee78a1b208382d3a26ec40d142ffc1ecc49ef"
 "checksum nvpair-sys 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5fc4cc751960db1094a7a732dd0706927aeae9194bf66c30fa227b70fc62b6c8"

--- a/device-aggregator/src/linux_plugin_transforms.rs
+++ b/device-aggregator/src/linux_plugin_transforms.rs
@@ -248,6 +248,13 @@ fn add_mount<'a>(
     d: &LinuxPluginDevice<'a>,
     linux_plugin_data: &mut LinuxPluginData<'a>,
 ) {
+    // This check is working around one cause of https://github.com/whamcloud/integrated-manager-for-lustre/issues/895
+    // Once we persist device-scanner input directly in the IML database, we won't need this fn anymore,
+    // as device-scanner correctly reports that the mount is transient.
+    if mount.target.0.as_os_str().len() == 14 && mount.target.0.to_string_lossy().starts_with("/tmp/mnt") {
+        return;
+    }
+
     linux_plugin_data
         .local_fs
         .insert(d.major_minor.clone(), (&mount.target, &mount.fs_type));
@@ -624,7 +631,12 @@ mod tests {
                   "/dev/dm-7"
                 ],
                 "children": [],
-                "mount": null
+                "mount": {
+                  "source": "/dev/dm-7",
+                  "target": "/tmp/mnt9aU7P6",
+                  "fs_type": "xfs",
+                  "opts": "rw,relatime,seclabel,attr2,inode64,noquota"
+                }
               }
             }
           ]

--- a/device-aggregator/src/linux_plugin_transforms.rs
+++ b/device-aggregator/src/linux_plugin_transforms.rs
@@ -251,7 +251,9 @@ fn add_mount<'a>(
     // This check is working around one cause of https://github.com/whamcloud/integrated-manager-for-lustre/issues/895
     // Once we persist device-scanner input directly in the IML database, we won't need this fn anymore,
     // as device-scanner correctly reports that the mount is transient.
-    if mount.target.0.as_os_str().len() == 14 && mount.target.0.to_string_lossy().starts_with("/tmp/mnt") {
+    if mount.target.0.as_os_str().len() == 14
+        && mount.target.0.to_string_lossy().starts_with("/tmp/mnt")
+    {
         return;
     }
 

--- a/device-scanner-daemon/src/reducers/snapshots/tests__reducers::mount::tests::test_mount_update.snap
+++ b/device-scanner-daemon/src/reducers/snapshots/tests__reducers::mount::tests::test_mount_update.snap
@@ -1,5 +1,5 @@
 ---
-created: "2019-05-10T21:38:38.959050Z"
+created: "2019-05-24T20:43:50.163951Z"
 creator: insta@0.8.1
 source: device-scanner-daemon/src/reducers/mount.rs
 expression: mounts
@@ -7,16 +7,16 @@ expression: mounts
 {
     Mount {
         source: DevicePath(
-            "/dev/sde1"
+            "/dev/sde1",
         ),
         target: MountPoint(
-            "/mnt/part1"
+            "/mnt/part1",
         ),
         fs_type: FsType(
-            "ext4"
+            "ext4",
         ),
         opts: MountOpts(
-            "rw,relatime,data=ordered"
-        )
-    }
+            "rw,relatime,data=ordered",
+        ),
+    },
 }

--- a/device-types/src/snapshots/tests__tests::test_device_path_ordering.snap
+++ b/device-types/src/snapshots/tests__tests::test_device_path_ordering.snap
@@ -1,26 +1,26 @@
 ---
-created: "2019-05-10T22:42:30.761813Z"
+created: "2019-05-24T20:44:42.659048Z"
 creator: insta@0.8.1
 source: device-types/src/lib.rs
 expression: xs
 ---
 {
     DevicePath(
-        "/dev/mapper/mpathd1"
+        "/dev/mapper/mpathd1",
     ),
     DevicePath(
-        "/dev/disk/by-id/dm-name-mpathd1"
+        "/dev/disk/by-id/dm-name-mpathd1",
     ),
     DevicePath(
-        "/dev/disk/by-id/dm-uuid-part1-mpath-3600140550e41a841db244a992c31e7df"
+        "/dev/disk/by-id/dm-uuid-part1-mpath-3600140550e41a841db244a992c31e7df",
     ),
     DevicePath(
-        "/dev/disk/by-partuuid/d643e32f-b6b9-4863-af8f-8950376e28da"
+        "/dev/disk/by-partuuid/d643e32f-b6b9-4863-af8f-8950376e28da",
     ),
     DevicePath(
-        "/dev/disk/by-uuid/b4550256-cf48-4013-8363-bfee5f52da12"
+        "/dev/disk/by-uuid/b4550256-cf48-4013-8363-bfee5f52da12",
     ),
     DevicePath(
-        "/dev/dm-20"
-    )
+        "/dev/dm-20",
+    ),
 }

--- a/mount-emitter/src/snapshots/tests__tests::test_line_to_hashmap_mount.snap
+++ b/mount-emitter/src/snapshots/tests__tests::test_line_to_hashmap_mount.snap
@@ -1,5 +1,5 @@
 ---
-created: "2019-05-10T16:06:50.598296Z"
+created: "2019-05-24T20:45:19.979239Z"
 creator: insta@0.8.1
 source: mount-emitter/src/lib.rs
 expression: map_to_sorted_vec(line_to_hashmap(line))
@@ -7,30 +7,30 @@ expression: map_to_sorted_vec(line_to_hashmap(line))
 [
     (
         "ACTION",
-        "mount"
+        "mount",
     ),
     (
         "FSTYPE",
-        "ext4"
+        "ext4",
     ),
     (
         "OLD-OPTIONS",
-        ""
+        "",
     ),
     (
         "OLD-TARGET",
-        ""
+        "",
     ),
     (
         "OPTIONS",
-        "rw,relatime,data=ordered"
+        "rw,relatime,data=ordered",
     ),
     (
         "SOURCE",
-        "/dev/sde1"
+        "/dev/sde1",
     ),
     (
         "TARGET",
-        "/mnt/part1"
-    )
+        "/mnt/part1",
+    ),
 ]

--- a/mount-emitter/src/snapshots/tests__tests::test_line_to_hashmap_swap.snap
+++ b/mount-emitter/src/snapshots/tests__tests::test_line_to_hashmap_swap.snap
@@ -1,5 +1,5 @@
 ---
-created: "2019-05-10T16:06:50.598295Z"
+created: "2019-05-24T20:45:19.979224Z"
 creator: insta@0.8.1
 source: mount-emitter/src/lib.rs
 expression: map_to_sorted_vec(line_to_hashmap(line))
@@ -7,18 +7,18 @@ expression: map_to_sorted_vec(line_to_hashmap(line))
 [
     (
         "FSTYPE",
-        "swap"
+        "swap",
     ),
     (
         "OPTIONS",
-        "defaults"
+        "defaults",
     ),
     (
         "SOURCE",
-        "/dev/mapper/centos-swap"
+        "/dev/mapper/centos-swap",
     ),
     (
         "TARGET",
-        "swap"
-    )
+        "swap",
+    ),
 ]

--- a/mount-emitter/src/snapshots/tests__tests::test_list_mount.snap
+++ b/mount-emitter/src/snapshots/tests__tests::test_list_mount.snap
@@ -1,20 +1,20 @@
 ---
-created: "2019-05-10T20:35:14.495803Z"
+created: "2019-05-24T20:45:19.979225Z"
 creator: insta@0.8.1
 source: mount-emitter/src/lib.rs
 expression: line_to_command(line)
 ---
 AddMount(
     MountPoint(
-        "/mnt/part1"
+        "/mnt/part1",
     ),
     DevicePath(
-        "/dev/sde1"
+        "/dev/sde1",
     ),
     FsType(
-        "ext4"
+        "ext4",
     ),
     MountOpts(
-        "rw,relatime,data=ordered"
-    )
+        "rw,relatime,data=ordered",
+    ),
 )

--- a/mount-emitter/src/snapshots/tests__tests::test_poll_mount.snap
+++ b/mount-emitter/src/snapshots/tests__tests::test_poll_mount.snap
@@ -1,20 +1,20 @@
 ---
-created: "2019-05-10T20:35:14.495803Z"
+created: "2019-05-24T20:45:19.979337Z"
 creator: insta@0.8.1
 source: mount-emitter/src/lib.rs
 expression: line_to_command(line)
 ---
 AddMount(
     MountPoint(
-        "/mnt/part1"
+        "/mnt/part1",
     ),
     DevicePath(
-        "/dev/sde1"
+        "/dev/sde1",
     ),
     FsType(
-        "ext4"
+        "ext4",
     ),
     MountOpts(
-        "rw,relatime,data=ordered"
-    )
+        "rw,relatime,data=ordered",
+    ),
 )

--- a/mount-emitter/src/snapshots/tests__tests::test_poll_move.snap
+++ b/mount-emitter/src/snapshots/tests__tests::test_poll_move.snap
@@ -1,23 +1,23 @@
 ---
-created: "2019-05-10T20:35:14.496247Z"
+created: "2019-05-24T20:45:19.979224Z"
 creator: insta@0.8.1
 source: mount-emitter/src/lib.rs
 expression: line_to_command(line)
 ---
 MoveMount(
     MountPoint(
-        "/mnt/part1a"
+        "/mnt/part1a",
     ),
     DevicePath(
-        "/dev/sde1"
+        "/dev/sde1",
     ),
     FsType(
-        "ext4"
+        "ext4",
     ),
     MountOpts(
-        "rw,relatime,data=ordered"
+        "rw,relatime,data=ordered",
     ),
     MountPoint(
-        "/mnt/part1"
-    )
+        "/mnt/part1",
+    ),
 )

--- a/mount-emitter/src/snapshots/tests__tests::test_poll_remount.snap
+++ b/mount-emitter/src/snapshots/tests__tests::test_poll_remount.snap
@@ -1,23 +1,23 @@
 ---
-created: "2019-05-10T20:35:14.495803Z"
+created: "2019-05-24T20:45:19.979224Z"
 creator: insta@0.8.1
 source: mount-emitter/src/lib.rs
 expression: line_to_command(line)
 ---
 ReplaceMount(
     MountPoint(
-        "/mnt/part1"
+        "/mnt/part1",
     ),
     DevicePath(
-        "/dev/sde1"
+        "/dev/sde1",
     ),
     FsType(
-        "ext4"
+        "ext4",
     ),
     MountOpts(
-        "ro,relatime,data=ordered"
+        "ro,relatime,data=ordered",
     ),
     MountOpts(
-        "rw,data=ordered"
-    )
+        "rw,data=ordered",
+    ),
 )

--- a/mount-emitter/src/snapshots/tests__tests::test_poll_umount.snap
+++ b/mount-emitter/src/snapshots/tests__tests::test_poll_umount.snap
@@ -1,20 +1,20 @@
 ---
-created: "2019-05-10T20:35:14.495803Z"
+created: "2019-05-24T20:45:19.979224Z"
 creator: insta@0.8.1
 source: mount-emitter/src/lib.rs
 expression: line_to_command(line)
 ---
 RemoveMount(
     MountPoint(
-        "/testPool4"
+        "/testPool4",
     ),
     DevicePath(
-        "testPool4"
+        "testPool4",
     ),
     FsType(
-        "zfs"
+        "zfs",
     ),
     MountOpts(
-        "rw,xattr,noacl"
-    )
+        "rw,xattr,noacl",
+    ),
 )

--- a/mount-emitter/src/snapshots/tests__tests::test_swap.snap
+++ b/mount-emitter/src/snapshots/tests__tests::test_swap.snap
@@ -1,20 +1,20 @@
 ---
-created: "2019-05-10T20:35:14.495803Z"
+created: "2019-05-24T20:45:19.979224Z"
 creator: insta@0.8.1
 source: mount-emitter/src/lib.rs
 expression: line_to_command(line)
 ---
 AddMount(
     MountPoint(
-        "swap"
+        "swap",
     ),
     DevicePath(
-        "/dev/mapper/centos-swap"
+        "/dev/mapper/centos-swap",
     ),
     FsType(
-        "swap"
+        "swap",
     ),
     MountOpts(
-        "defaults"
-    )
+        "defaults",
+    ),
 )

--- a/mount-emitter/src/snapshots/tests__tests::test_swap_extra.snap
+++ b/mount-emitter/src/snapshots/tests__tests::test_swap_extra.snap
@@ -1,20 +1,20 @@
 ---
-created: "2019-05-10T20:35:14.497325Z"
+created: "2019-05-24T20:45:20.014363Z"
 creator: insta@0.8.1
 source: mount-emitter/src/lib.rs
 expression: line_to_command(line)
 ---
 AddMount(
     MountPoint(
-        "swap"
+        "swap",
     ),
     DevicePath(
-        "/dev/mapper/VolGroup00-LogVol01"
+        "/dev/mapper/VolGroup00-LogVol01",
     ),
     FsType(
-        "swap"
+        "swap",
     ),
     MountOpts(
-        "defaults"
-    )
+        "defaults",
+    ),
 )


### PR DESCRIPTION
In https://github.com/whamcloud/integrated-manager-for-lustre/issues/895
we are seeing a `VolumeNode` being removed when creating a Lustre fs.

Lustre is creating a temporary mount under `/tmp/mntXXXXXX` and this is
being picked up by resource_manager.py

Although the mount is transient, the resource_manager does not remove it
from the IML db once it's been unmounted.

As a temporary workaround, prevent these mounts from appearing in
device-aggregator output, which will prevent resource_manager.py from
knowing about their existence and creating stale `LocalMount`s.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>