### PR TITLE
Use single-threaded runtime for zed-enhancer daemon

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,7 +41,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "backtrace"
-version = "0.3.24"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "autocfg 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -300,7 +300,7 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
-version = "0.14.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -431,7 +431,7 @@ name = "failure"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "backtrace 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "backtrace 0.3.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2093,7 +2093,7 @@ dependencies = [
 name = "zed-enhancer"
 version = "0.1.0"
 dependencies = [
- "derive_more 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "derive_more 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "device-types 0.1.0",
  "env_logger 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2110,7 +2110,7 @@ dependencies = [
 "checksum arrayvec 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "92c7fb76bc8826a8b33b4ee5bb07a247a81e76764ab4d55e8f73e3a4d8808c71"
 "checksum atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "9a7d5b8723950951411ee34d271d99dddcc2035a16ab25310ea2c8cfd4369652"
 "checksum autocfg 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "0e49efa51329a5fd37e7c79db4621af617cd4e3e5bc224939808d076077077bf"
-"checksum backtrace 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "8ca8a0a1f68b5d04b8d006c726d16e38455fc8886c51fff7c2e6df32333378e2"
+"checksum backtrace 0.3.26 (registry+https://github.com/rust-lang/crates.io-index)" = "1a13fc43f04daf08ab4f71e3d27e1fc27fc437d3e95ac0063a796d92fb40f39b"
 "checksum backtrace-sys 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)" = "797c830ac25ccc92a7f8a7b9862bde440715531514594a6154e3d4a54dd769b6"
 "checksum base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
 "checksum bindgen 0.43.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6d52d263eacd15d26cbcf215d254b410bd58212aaa2d3c453a04b2d3b3adcf41"
@@ -2138,7 +2138,7 @@ dependencies = [
 "checksum crossbeam-utils 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "f8306fcef4a7b563b76b7dd949ca48f52bc1141aa067d2ea09565f3e2652aa5c"
 "checksum cstr-argument 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20bd4e8067c20c7c3a4dea759ef91d4b18418ddb5bd8837ef6e2f2f93ca7ccbb"
 "checksum ctor 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "3b4c17619643c1252b5f690084b82639dd7fac141c57c8e77a00e0148132092c"
-"checksum derive_more 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fbe9f11be34f800b3ecaaed0ec9ec2e015d1d0ba0c8644c1310f73d6e8994615"
+"checksum derive_more 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6d944ac6003ed268757ef1ee686753b57efc5fcf0ebe7b64c9fc81e7e32ff839"
 "checksum difference 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
 "checksum digest 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "05f47366984d3ad862010e22c7ce81a7dbcaebbdfb37241a620f8b6596ee135c"
 "checksum dtoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "ea57b42383d091c85abcc2706240b94ab2a8fa1fc81c10ff23c4de06e2a90b5e"

--- a/zed-enhancer/src/lib.rs
+++ b/zed-enhancer/src/lib.rs
@@ -3,12 +3,12 @@
 // license that can be found in the LICENSE file.
 
 use device_types::zed::{zfs, zpool, PoolCommand, ZedCommand};
+use futures::{Future, Stream};
 use std::{error, fmt, io, io::BufReader, num, os::unix::net::UnixStream as NetUnixStream, result};
 use tokio::{
     io::lines,
     io::{AsyncRead, AsyncWrite},
     net::UnixStream,
-    prelude::*,
     reactor::Handle,
 };
 
@@ -115,7 +115,7 @@ pub fn processor(socket: UnixStream) -> impl Future<Item = (), Error = Error> {
         .map(device_types::Command::PoolCommand)
         .and_then(|x| serde_json::to_string(&x).map_err(Error::SerdeJson))
         .for_each(|x| {
-            log::debug!("sending out: {:?}", x);
+            log::debug!("Sending: {:?}", x);
 
             tokio::io::write_all(get_write_stream(), x)
                 .map(|_| ())

--- a/zed-enhancer/src/lib.rs
+++ b/zed-enhancer/src/lib.rs
@@ -51,7 +51,7 @@ fn guid_to_u64(guid: zpool::Guid) -> Result<u64> {
 
 /// Takes a ZedCommand and produces some PoolCommands.
 pub fn handle_zed_commands(cmd: ZedCommand) -> Result<PoolCommand> {
-    log::debug!("got cmd: {:?}", cmd);
+    log::debug!("Processing ZED event: {:?}", cmd);
 
     match cmd {
         ZedCommand::Init => {

--- a/zed-enhancer/src/main.rs
+++ b/zed-enhancer/src/main.rs
@@ -26,7 +26,7 @@ fn main() {
         .incoming()
         .map_err(|e| log::error!("accept failed, {:?}", e))
         .for_each(move |socket| {
-            tokio::spawn(processor(socket).map_err(|e| log::error!("Unhandled Error: {:?}", e)))
+            processor(socket).map_err(|e| log::error!("Unhandled Error: {:?}", e))
         });
 
     log::info!("Server starting");

--- a/zed-enhancer/src/main.rs
+++ b/zed-enhancer/src/main.rs
@@ -31,15 +31,7 @@ fn main() {
 
     log::info!("Server starting");
 
-    let mut runtime = tokio::runtime::Builder::new()
-        .panic_handler(|err| std::panic::resume_unwind(err))
-        .build()
-        .expect("Tokio runtime failed to start");
+    let mut runtime = tokio::runtime::current_thread::Runtime::new().unwrap();
 
-    runtime.spawn(server);
-
-    runtime
-        .shutdown_on_idle()
-        .wait()
-        .expect("Failed to shutdown runtime");
+    runtime.block_on(server).unwrap();
 }


### PR DESCRIPTION
ZED events are emitted by a single thread, however the zed-enhancer
daemon is multithreaded. This means if there are multiple incoming ZED
events in a short time span, they may finish out of order.

Switch to using the single threaded runtime for zed-enhancer so events
are guaranteed to be processed serially.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>