### PR TITLE
Add lv name and uuid to LinuxPluginLvDevice

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,12 @@ jobs:
   include:
     - stage: test
       name: "Unit Tests"
-      rust: 1.35.0
+      rust: 1.36.0
       script:
         - cargo test --exclude zed-enhancer --all
     - stage: test
       name: "Format Check"
-      rust: 1.35.0
+      rust: 1.36.0
       before_script:
         - rustup component add rustfmt
       script:

--- a/device-aggregator/src/linux_plugin_transforms.rs
+++ b/device-aggregator/src/linux_plugin_transforms.rs
@@ -421,17 +421,17 @@ pub fn devtree2linuxoutput<'a>(
                         .devs
                         .insert(d.major_minor.clone(), LinuxPluginItem::LinuxPluginDevice(d));
 
-                    let vgs = linux_plugin_data
+                    linux_plugin_data
                         .lvs
                         .entry(vg_name.clone())
-                        .or_insert_with(BTreeMap::new);
-
-                    vgs.entry(x.name.clone()).or_insert(LinuxPluginLvDevice {
-                        name: &x.name,
-                        size: x.size,
-                        uuid: &x.uuid,
-                        block_device,
-                    });
+                        .or_insert_with(BTreeMap::new)
+                        .entry(lv.name.clone())
+                        .or_insert(LinuxPluginLvDevice {
+                            name: &lv.name,
+                            size: lv.size,
+                            uuid: &lv.uuid,
+                            block_device,
+                        });
                 });
         }
         Device::Zpool(x) => {

--- a/device-aggregator/src/snapshots/tests__linux_plugin_transforms::tests::test_devtree2linuxoutput.snap
+++ b/device-aggregator/src/snapshots/tests__linux_plugin_transforms::tests::test_devtree2linuxoutput.snap
@@ -1,5 +1,5 @@
 ---
-created: "2019-05-17T21:18:18.146376Z"
+created: "2019-08-03T19:52:12.667016Z"
 creator: insta@0.8.1
 source: device-aggregator/src/linux_plugin_transforms.rs
 expression: data
@@ -1797,11 +1797,11 @@ expression: data
   },
   "lvs": {
     "vg1": {
-      "vg1": {
+      "lv1": {
         "block_device": "253:20",
-        "size": 0,
-        "uuid": "UDIbPXrzaeBLNKim8kDOqcWfXbG2eRKt",
-        "name": "vg1"
+        "size": 67108864,
+        "uuid": "9rYEeS4U3eCNTgx1UovfQIXv16TTjel4",
+        "name": "lv1"
       }
     }
   },

--- a/device-scanner-daemon/src/state.rs
+++ b/device-scanner-daemon/src/state.rs
@@ -529,7 +529,7 @@ pub fn handler() -> (
                     let b = bytes::BytesMut::from(v + "\n");
                     let b = b.freeze();
 
-                    connections_tx.unbounded_send(b.clone()).is_ok();
+                    let _ = connections_tx.unbounded_send(b.clone()).is_ok();
 
                     return Ok(State {
                         conns,

--- a/device-scanner-proxy/src/main.rs
+++ b/device-scanner-proxy/src/main.rs
@@ -50,9 +50,9 @@ fn get_authority_cert_path() -> String {
     required("AUTHORITY_CRT_PATH")
 }
 
-/// Gets the pfx file.
-/// If pfx is not found it will be created.
 lazy_static! {
+    // Gets the pfx file.
+    // If pfx is not found it will be created.
     pub static ref PFX: Vec<u8> = {
         let private_pem_path = get_private_pem_path();
 


### PR DESCRIPTION
The device-aggregator is adding vg name and uuid to `LinuxPluginLvDevice` output.

Instead it should be adding that data from the incoming `LogicalVolume`.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>