### PR TITLE
Remove postun scriptlet

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -12,6 +12,8 @@ build: $(CARGO)
 
 	rm -rf ${BUILDROOT}/_topdir
 
+	yum install -y gcc-c++
+
 	if ! rpm -q dotnet-sdk-2.1 2> /dev/null; then \
 		yum-config-manager --add-repo=https://packages.microsoft.com/rhel/7/prod; \
 		yum-config-manager --add-repo=http://download.mono-project.com/repo/centos7-stable.repo; \
@@ -39,7 +41,7 @@ build: $(CARGO)
 
 	cd ${TMPDIR}/scratch && \
 		npm i --ignore-scripts && \
-		npm i iltorb && \
+		npm i iltorb@2.0.5 && \
 		npm run restore && \
 		dotnet fable npm-run build && \
 		npm pack;

--- a/iml-device-scanner.spec
+++ b/iml-device-scanner.spec
@@ -7,7 +7,7 @@
 %define     aggregator_prefixed iml-%{aggregator_name}
 
 Name:       iml-%{base_name}
-Version:    2.2.1
+Version:    2.2.2
 # Release Start
 Release:    1%{?dist}
 # Release End
@@ -204,21 +204,10 @@ fi
 %systemd_preun %{aggregator_name}.socket
 %systemd_preun %{aggregator_name}.service
 
-%postun
-%systemd_postun_with_restart %{base_name}.socket
-
-if [ $1 -ge 1 ] ; then
-  udevadm trigger --action=change --subsystem-match=block
-  systemctl start %{mount_name}.service
-fi
-
-%postun proxy
-%systemd_postun_with_restart %{proxy_name}.path
-
-%postun aggregator
-%systemd_postun_with_restart %{aggregator_name}.socket
-
 %changelog
+* Sun Nov 10 2019 Joe Grund <jgrund@whamcloud.com> - 2.2.2-1
+- Remove postun scriptlets
+
 * Fri May 10 2019 Will Johnson <wjohnson@whamcloud.com> - 2.2.1-1
 - Fix device-scanner.socket to be wanted by iml-manager.target.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@iml/device-scanner",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@iml/device-scanner",
   "description": "Builds an in-memory representation of devices. Uses udev rules to handle change events.",
   "author": "IML Team",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "license": "MIT",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Remove the postun scriptlet since we manually restart the top level
storage-server.target in IML 5.1.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>