### PR TITLE
Add rotational property to UEvent

### DIFF
--- a/device-scanner-daemon/src/reducers/udev.rs
+++ b/device-scanner-daemon/src/reducers/udev.rs
@@ -45,6 +45,7 @@ mod tests {
             part_entry_number: Some(1),
             part_entry_mm: Some("253:13".to_string()),
             size: Some(100_651_008),
+            rotational: Some(false),
             scsi80: Some(
                 "SLIO-ORG ost12           50e41a84-1db2-44a9-92c3-1e7dfad48fce".to_string(),
             ),

--- a/device-types/src/uevent.rs
+++ b/device-types/src/uevent.rs
@@ -26,6 +26,7 @@ pub struct UEvent {
     pub part_entry_number: Option<u64>,
     pub part_entry_mm: Option<String>,
     pub size: Option<u64>,
+    pub rotational: Option<bool>,
     pub scsi80: Option<String>,
     pub scsi83: Option<String>,
     pub read_only: Option<bool>,

--- a/uevent-listener/src/main.rs
+++ b/uevent-listener/src/main.rs
@@ -114,6 +114,7 @@ pub fn build_uevent() -> UEvent {
             .and_then(empty_str_to_none)
             .and_then(parse_to)
             .map(|x: u64| x * 512),
+        rotational: optional_field("IML_ROTATIONAL").map(is_one),
         scsi80: optional_field("IML_SCSI_80").map(|x| x.trim().to_string()),
         scsi83: optional_field("IML_SCSI_83").map(|x| x.trim().to_string()),
         read_only: optional_field("IML_IS_RO").map(is_one),

--- a/uevent-listener/udev-rules/99-iml-device-scanner.rules
+++ b/uevent-listener/udev-rules/99-iml-device-scanner.rules
@@ -19,6 +19,9 @@ ACTION=="add|change", ENV{DM_UUID}=="mpath-?*", ENV{IML_IS_MPATH}="1"
 # Get ro state whenever there is an add or change on the device
 ACTION=="add|change", PROGRAM="/sbin/blockdev --getro $devnode", RESULT=="?*", ENV{IML_IS_RO}="$result"
 
+# Read rotational state property from /sys and add it to the device
+ACTION=="add|change", ENV{IML_ROTATIONAL}="$attr{queue/rotational}"
+
 # Read size from /sys and add it to the device
 ACTION=="add|change", ENV{IML_SIZE}="$attr{size}"
 


### PR DESCRIPTION
Add a new rotational property to UEvent that will (most likely) tell if
a device is HDD or SSD.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>