### PR TITLE
Add shared VGs and LVs

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -23,4 +23,4 @@ srpm: $(CARGO)
 	cp iml-device-scanner.spec ${TMPDIR}/_topdir/SPECS/
 	rpmbuild -bs -D "_topdir ${TMPDIR}/_topdir" ${TMPDIR}/_topdir/SPECS/iml-device-scanner.spec
 	cp -rf ${TMPDIR}/_topdir ${BUILDROOT}/
-	cp -f _topdir/SRPMS/*.rpm $(outdir)
+	cp -f ${TMPDIR}/_topdir/SRPMS/*.rpm $(outdir)

--- a/.github/actions/copr-zfs/action.yml
+++ b/.github/actions/copr-zfs/action.yml
@@ -1,0 +1,5 @@
+name: copr zfs
+description: build in the copr-zfs image
+runs:
+  using: "docker"
+  image: "docker://imlteam/copr-zfs"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,71 @@
+name: Device Scanner CI
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+jobs:
+  check:
+    name: Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: check
+          args: --locked --exclude zed-enhancer --all
+
+  clippy:
+    name: Clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - run: rustup component add clippy
+      - uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --locked --exclude zed-enhancer --all -- -W warnings
+
+  rustfmt:
+    name: Format
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - run: rustup component add rustfmt
+      - uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all -- --check
+
+  check_rpm_build:
+    name: Check RPM build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v1
+
+      - name: Build rpm
+        uses: ./.github/actions/copr-zfs
+        env:
+          SPEC: iml-device-scanner.spec
+          LOCAL_ONLY: true
+          WORKSPACE: ${{ github.workspace }}
+          RUSTUP_TOOLCHAIN: stable-x86_64-unknown-linux-gnu
+      - name: Archive rpm
+        uses: actions/upload-artifact@v1
+        with:
+          name: rpm
+          path: _topdir/RPMS/x86_64

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,22 @@ jobs:
           command: fmt
           args: --all -- --check
 
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+
+      - name: Run cargo test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --locked --exclude zed-enhancer --all
+
   check_rpm_build:
     name: Check RPM build
     runs-on: ubuntu-latest

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,33 +3,6 @@ cache: cargo
 
 jobs:
   include:
-    - stage: test
-      name: "Unit Tests"
-      rust: stable
-      script:
-        - cargo test --exclude zed-enhancer --all
-    - stage: test
-      name: "Rustfmt"
-      rust: stable
-      before_script:
-        - rustup component add rustfmt
-      script:
-        - cargo fmt --all -- --check
-    - stage: test
-      name: "copr build test"
-      language: generic
-      script:
-        - export SPEC=iml-device-scanner.spec
-        - docker run -it -e SPEC="$SPEC" -e LOCAL_ONLY="True" -v $(pwd):/build:rw imlteam/copr-zfs
-        - ((`find _topdir/RPMS -name *.rpm | wc -l` > 0))
-    - stage: test
-      name: "Linting Check"
-      language: generic
-      script:
-        - docker run -d -it --name libzfs -v $(pwd):/device-scanner:rw imlteam/zfs
-        - docker exec -i libzfs bash -c 'yum install -y openssl-devel'
-        - docker exec -i libzfs bash -c 'rustup default stable; rustup component add clippy'
-        - docker exec -i libzfs bash -c 'cd /device-scanner && cargo clippy --all-targets --all-features -- -D warnings'
     - stage: cd
       name: "Continuous Deployment"
       language: generic

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -136,7 +136,7 @@ dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.105 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -360,9 +360,8 @@ dependencies = [
  "insta 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "pretty_assertions 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.105 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-mockstream 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "warp 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -378,8 +377,8 @@ dependencies = [
  "im 13.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "insta 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libzfs-types 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.105 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.2.0-alpha.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tracing 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "tracing-subscriber 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -397,9 +396,8 @@ dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "native-tls 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "pretty_assertions 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.105 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-mockstream 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-tls 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -410,7 +408,7 @@ name = "device-scanner-zedlets"
 version = "0.1.0"
 dependencies = [
  "device-types 0.1.3",
- "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -422,8 +420,8 @@ dependencies = [
  "libzfs-types 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "pretty_assertions 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.105 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -763,7 +761,7 @@ version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.105 (registry+https://github.com/rust-lang/crates.io-index)",
  "sized-chunks 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "typenum 1.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -792,8 +790,8 @@ dependencies = [
  "console 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "difference 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.105 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_yaml 0.8.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -806,8 +804,8 @@ dependencies = [
  "console 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "difference 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.105 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_yaml 0.8.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -867,8 +865,8 @@ dependencies = [
  "libzfs-sys 0.5.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "libzfs-types 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "nvpair-sys 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.105 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.105 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -886,8 +884,8 @@ name = "libzfs-types"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.105 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.105 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1049,7 +1047,7 @@ dependencies = [
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "insta 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pretty_assertions 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-file-unix 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-mockstream 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1604,15 +1602,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde"
-version = "1.0.102"
+version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde_derive 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.105 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.102"
+version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1622,12 +1620,12 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.41"
+version = "1.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "ryu 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.105 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1637,7 +1635,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "dtoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.105 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1648,7 +1646,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "dtoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "linked-hash-map 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.105 (registry+https://github.com/rust-lang/crates.io-index)",
  "yaml-rust 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2270,7 +2268,7 @@ dependencies = [
  "device-types 0.1.3",
  "im 13.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pretty_assertions 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2351,7 +2349,7 @@ version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.105 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2360,7 +2358,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.105 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2403,8 +2401,8 @@ dependencies = [
  "mime_guess 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "multipart 0.16.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "scoped-tls 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.105 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_urlencoded 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2498,7 +2496,7 @@ dependencies = [
  "futures-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "libzfs 0.6.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "libzfs-types 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.2.0-alpha.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-net 0.2.0-alpha.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tracing 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2678,9 +2676,9 @@ dependencies = [
 "checksum security-framework-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e31493fc37615debb8c5090a7aeb4a9730bc61e77ab10b9af59f1a202284f895"
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
-"checksum serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)" = "0c4b39bd9b0b087684013a792c59e3e07a46a01d2322518d8a1104641a0b1be0"
-"checksum serde_derive 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)" = "ca13fc1a832f793322228923fbb3aba9f3f44444898f835d31ad1b74fa0a2bf8"
-"checksum serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)" = "2f72eb2a68a7dc3f9a691bfda9305a1c017a6215e5a4545c258500d2099a37c2"
+"checksum serde 1.0.105 (registry+https://github.com/rust-lang/crates.io-index)" = "e707fbbf255b8fc8c3b99abb91e7257a622caeb20a9818cbadbeeede4e0932ff"
+"checksum serde_derive 1.0.105 (registry+https://github.com/rust-lang/crates.io-index)" = "ac5d00fc561ba2724df6758a17de23df5914f20e41cb00f94d5b7ae42fffaff8"
+"checksum serde_json 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)" = "9371ade75d4c2d6cb154141b9752cf3781ec9c05e0e5cf35060e1e70ee7b9c25"
 "checksum serde_urlencoded 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9ec5d77e2d4c73717816afac02670d5c4f534ea95ed430442cad02e7a6e32c97"
 "checksum serde_yaml 0.8.11 (registry+https://github.com/rust-lang/crates.io-index)" = "691b17f19fc1ec9d94ec0b5864859290dff279dbd7b03f017afda54eb36c3c35"
 "checksum sha-1 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "23962131a91661d643c98940b20fcaffe62d776a823247be80a48fcb8b6fce68"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.39 as builder
+FROM rust:1.42 as builder
 WORKDIR /build
 COPY . .
 RUN cargo build -p device-aggregator --release

--- a/device-aggregator/Cargo.toml
+++ b/device-aggregator/Cargo.toml
@@ -11,9 +11,8 @@ env_logger = "0.6"
 tokio = "0.1"
 futures = "0.1"
 warp = "0.1"
-serde = "1.0"
-serde_derive = "1.0"
-serde_json = "1.0"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 device-types = { path = "../device-types", version = "0.1.0" }
 
 

--- a/device-aggregator/src/aggregator_error.rs
+++ b/device-aggregator/src/aggregator_error.rs
@@ -3,7 +3,7 @@
 // license that can be found in the LICENSE file.
 
 use serde_json;
-use std::{error, fmt, io, str};
+use std::{error, fmt, io};
 use tokio::timer;
 
 #[derive(Debug)]
@@ -24,14 +24,6 @@ impl fmt::Display for Error {
 }
 
 impl error::Error for Error {
-    fn description(&self) -> &str {
-        match *self {
-            Error::Io(ref err) => err.description(),
-            Error::Timer(ref err) => err.description(),
-            Error::SerdeJsonError(ref err) => err.description(),
-        }
-    }
-
     fn cause(&self) -> Option<&dyn error::Error> {
         match *self {
             Error::Io(ref err) => Some(err),

--- a/device-aggregator/src/linux_plugin_transforms.rs
+++ b/device-aggregator/src/linux_plugin_transforms.rs
@@ -542,7 +542,7 @@ pub fn get_shared_pools<'a, S: ::std::hash::BuildHasher>(
 }
 
 /// Given some aggregated data
-/// Figure out what VGs can be shared between hosts and add them to the otehr hosts.
+/// Figure out what VGs can be shared between hosts and add them to the other hosts.
 pub fn update_vgs<'a>(
     mut xs: BTreeMap<&'a String, LinuxPluginData<'a>>,
 ) -> BTreeMap<&'a String, LinuxPluginData<'a>> {
@@ -572,7 +572,7 @@ pub fn update_vgs<'a>(
         acc
     });
 
-    for (from_host, to_host, vg_name) in shared_vgs.into_iter() {
+    for (from_host, to_host, vg_name) in shared_vgs {
         let from = xs.get(from_host).unwrap();
 
         let vg = from.vgs.get(vg_name).cloned().unwrap();

--- a/device-aggregator/src/main.rs
+++ b/device-aggregator/src/main.rs
@@ -6,7 +6,8 @@ use device_aggregator::{
     aggregator_error,
     cache::{Cache, CacheFlush},
     linux_plugin_transforms::{
-        build_device_lookup, devtree2linuxoutput, get_shared_pools, populate_zpool, LinuxPluginData,
+        build_device_lookup, devtree2linuxoutput, get_shared_pools, populate_zpool, update_vgs,
+        LinuxPluginData,
     },
 };
 use device_types::{devices::Device, message::Message};
@@ -105,6 +106,8 @@ fn main() -> Result<(), aggregator_error::Error> {
                     populate_zpool(a, b, x);
                 }
             }
+
+            let xs = update_vgs(xs);
 
             serde_json::to_string(&xs).unwrap()
         });

--- a/device-aggregator/src/main.rs
+++ b/device-aggregator/src/main.rs
@@ -107,7 +107,7 @@ fn main() -> Result<(), aggregator_error::Error> {
                 }
             }
 
-            let xs = update_vgs(xs);
+            let xs = update_vgs(xs, &path_index);
 
             serde_json::to_string(&xs).unwrap()
         });

--- a/device-aggregator/src/snapshots/tests__devtree2linuxoutput.snap
+++ b/device-aggregator/src/snapshots/tests__devtree2linuxoutput.snap
@@ -1,6 +1,4 @@
 ---
-created: "2019-08-25T21:51:04.635167Z"
-creator: insta@0.10.1
 source: device-aggregator/src/linux_plugin_transforms.rs
 expression: data
 ---
@@ -212,23 +210,6 @@ expression: data
       "serial_83": "3600140547e0ffe43b3f464789f1653cc",
       "serial_80": "SLIO-ORG ost11           47e0ffe4-3b3f-4647-89f1-653cc1b7c954",
       "size": 5368709120,
-      "filesystem_type": null
-    },
-    "253:20": {
-      "major_minor": "253:20",
-      "parent": null,
-      "partition_number": null,
-      "path": "/dev/mapper/vg1-lv1",
-      "paths": [
-        "/dev/mapper/vg1-lv1",
-        "/dev/disk/by-id/dm-name-vg1-lv1",
-        "/dev/disk/by-id/dm-uuid-LVM-UDIbPXrzaeBLNKim8kDOqcWfXbG2eRKt9rYEeS4U3eCNTgx1UovfQIXv16TTjel4",
-        "/dev/dm-20",
-        "/dev/vg1/lv1"
-      ],
-      "serial_83": null,
-      "serial_80": null,
-      "size": 67108864,
       "filesystem_type": null
     },
     "253:3": {
@@ -1015,6 +996,23 @@ expression: data
       "serial_80": "SLIO-ORG ost3            1ea57ad4-ffc2-43d6-bcab-8eb8c2a60bfb",
       "size": 5368709120,
       "filesystem_type": "mpath_member"
+    },
+    "lv:9rYEeS4U3eCNTgx1UovfQIXv16TTjel4": {
+      "major_minor": "lv:9rYEeS4U3eCNTgx1UovfQIXv16TTjel4",
+      "parent": null,
+      "partition_number": null,
+      "path": "/dev/mapper/vg1-lv1",
+      "paths": [
+        "/dev/mapper/vg1-lv1",
+        "/dev/disk/by-id/dm-name-vg1-lv1",
+        "/dev/disk/by-id/dm-uuid-LVM-UDIbPXrzaeBLNKim8kDOqcWfXbG2eRKt9rYEeS4U3eCNTgx1UovfQIXv16TTjel4",
+        "/dev/dm-20",
+        "/dev/vg1/lv1"
+      ],
+      "serial_83": null,
+      "serial_80": null,
+      "size": 67108864,
+      "filesystem_type": null
     }
   },
   "local_fs": {
@@ -1798,7 +1796,7 @@ expression: data
   "lvs": {
     "vg1": {
       "lv1": {
-        "block_device": "253:20",
+        "block_device": "lv:9rYEeS4U3eCNTgx1UovfQIXv16TTjel4",
         "size": 67108864,
         "uuid": "9rYEeS4U3eCNTgx1UovfQIXv16TTjel4",
         "name": "lv1"

--- a/device-scanner-daemon/src/reducers/udev.rs
+++ b/device-scanner-daemon/src/reducers/udev.rs
@@ -81,9 +81,9 @@ mod tests {
 
         let uevents = update_udev(&uevents, change_cmd);
 
-        assert_eq!(hashmap! {ev.devpath.clone() => ev2.clone()}, uevents);
+        assert_eq!(hashmap! {ev.devpath => ev2.clone()}, uevents);
 
-        let remove_cmd = UdevCommand::Remove(ev2.clone());
+        let remove_cmd = UdevCommand::Remove(ev2);
 
         let uevents = update_udev(&uevents, remove_cmd);
 

--- a/device-scanner-proxy/Cargo.toml
+++ b/device-scanner-proxy/Cargo.toml
@@ -12,9 +12,8 @@ native-tls = "0.2.3"
 lazy_static = "1.3.0"
 futures = "0.1"
 hyper = "0.12"
-serde = "1.0"
-serde_derive = "1.0"
-serde_json = "1.0"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 failure = "0.1.5"
 futures-failure = { path = "../futures-failure", version = "0.1.0" }
 device-types = { path = "../device-types", version = "0.1.0" }

--- a/device-scanner-zedlets/src/lib.rs
+++ b/device-scanner-zedlets/src/lib.rs
@@ -118,7 +118,7 @@ pub mod zed {
         let xs: Vec<&str> = x.split('=').collect();
 
         match &xs[..] {
-            [a, b] => Ok((prop::Key(a.to_string()), prop::Value(b.to_string()))),
+            [a, b] => Ok((prop::Key((*a).to_string()), prop::Value((*b).to_string()))),
             _ => Err(env::VarError::NotPresent),
         }
     }

--- a/device-types/src/lib.rs
+++ b/device-types/src/lib.rs
@@ -99,12 +99,10 @@ impl Ord for DevicePath {
         let a_slot = find_sort_slot(self);
         let b_slot = find_sort_slot(other);
 
-        if a_slot > b_slot {
-            Ordering::Greater
-        } else if a_slot < b_slot {
-            Ordering::Less
-        } else {
-            self.0.partial_cmp(&other.0).unwrap()
+        match a_slot.cmp(&b_slot) {
+            Ordering::Greater => Ordering::Greater,
+            Ordering::Less => Ordering::Less,
+            Ordering::Equal => self.0.partial_cmp(&other.0).unwrap(),
         }
     }
 }

--- a/mount-emitter/src/lib.rs
+++ b/mount-emitter/src/lib.rs
@@ -79,7 +79,7 @@ fn build_hashmap(mut acc: IntermediateMap, x: &str) -> IntermediateMap {
         _ => panic!("Expected two matches from: {:?}", xs),
     };
 
-    acc.insert(k.to_string(), v.to_string());
+    acc.insert((*k).to_string(), v.to_string());
 
     acc
 }

--- a/mount-emitter/tests/integration_tests.rs
+++ b/mount-emitter/tests/integration_tests.rs
@@ -63,7 +63,7 @@ fn test_polling_cmd() {
         ACTION=\"umount\" TARGET=\"/testPool4\" SOURCE=\"testPool4\" FSTYPE=\"zfs\" OPTIONS=\"rw,xattr,noacl\" OLD-TARGET=\"/testPool4\" OLD-OPTIONS=\"rw,xattr,noacl\"";
 
     let expected = vec![
-        r#"{"MountCommand":{"AddMount":["/testPool4","testPool4","zfs","rw,xattr,noacl"]}}"#, 
+        r#"{"MountCommand":{"AddMount":["/testPool4","testPool4","zfs","rw,xattr,noacl"]}}"#,
         r#"{"MountCommand":{"AddMount":["/testPool4/home","testPool4/home","zfs","rw,xattr,noacl"]}}"#,
         r#"{"MountCommand":{"RemoveMount":["/testPool4/home","testPool4/home","zfs","rw,xattr,noacl"]}}"#,
         r#"{"MountCommand":{"RemoveMount":["/testPool4","testPool4","zfs","rw,xattr,noacl"]}}"#,


### PR DESCRIPTION
When a VG is present in a device tree, we can tell if it can be used on
another host by inspecting the underlying PVs.

If all PVs are present on another host, then we can presume the VG can
be available on that host as well.

Add a fn that will look at the PVs and add VGs / LVs to other hosts when
they match.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>