### PR TITLE
Use OrdSet for children

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -316,7 +316,7 @@ dependencies = [
  "futures-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "im 13.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "insta 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libzfs-types 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libzfs-types 0.1.2 (git+https://github.com/whamcloud/rust-libzfs.git)",
  "serde 1.0.105 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.2.0-alpha.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -338,7 +338,7 @@ version = "0.1.4"
 dependencies = [
  "im 13.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "insta 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libzfs-types 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libzfs-types 0.1.2 (git+https://github.com/whamcloud/rust-libzfs.git)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "pretty_assertions 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.105 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -633,14 +633,14 @@ dependencies = [
 
 [[package]]
 name = "libzfs"
-version = "0.6.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+version = "0.6.16"
+source = "git+https://github.com/whamcloud/rust-libzfs.git#6041b5e746cdaff54552b9c53163686378f74bdf"
 dependencies = [
  "cstr-argument 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libzfs-sys 0.5.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "libzfs-types 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libzfs-sys 0.5.11 (git+https://github.com/whamcloud/rust-libzfs.git)",
+ "libzfs-types 0.1.2 (git+https://github.com/whamcloud/rust-libzfs.git)",
  "nvpair-sys 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.105 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.105 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -649,7 +649,7 @@ dependencies = [
 [[package]]
 name = "libzfs-sys"
 version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/whamcloud/rust-libzfs.git#6041b5e746cdaff54552b9c53163686378f74bdf"
 dependencies = [
  "bindgen 0.51.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "nvpair-sys 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -658,8 +658,8 @@ dependencies = [
 
 [[package]]
 name = "libzfs-types"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+version = "0.1.2"
+source = "git+https://github.com/whamcloud/rust-libzfs.git#6041b5e746cdaff54552b9c53163686378f74bdf"
 dependencies = [
  "serde 1.0.105 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.105 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1879,8 +1879,8 @@ dependencies = [
  "derive_more 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "device-types 0.1.4",
  "futures-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "libzfs 0.6.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "libzfs-types 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libzfs 0.6.16 (git+https://github.com/whamcloud/rust-libzfs.git)",
+ "libzfs-types 0.1.2 (git+https://github.com/whamcloud/rust-libzfs.git)",
  "serde_json 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.2.0-alpha.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-net 0.2.0-alpha.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1955,9 +1955,9 @@ dependencies = [
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 "checksum libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)" = "1a31a0627fdf1f6a39ec0dd577e101440b7db22672c0901fe00a9a6fbb5c24e8"
 "checksum libloading 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f2b111a074963af1d37a139918ac6d49ad1d0d5e47f72fd55388619691a7d753"
-"checksum libzfs 0.6.15 (registry+https://github.com/rust-lang/crates.io-index)" = "b5acaccfc773fcb0a9f851fd613c51f4fbe9ae6efd2e6243ad6fd6d1979fe60d"
-"checksum libzfs-sys 0.5.11 (registry+https://github.com/rust-lang/crates.io-index)" = "e3e9a517de5cf7d5c5c5da6b2e1db3bca39201e6d9bd91702dda1e40780effcc"
-"checksum libzfs-types 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "781e3a0e71718873e3fb34ba980a2ff855079c2685d36c78c3df5586a9379bca"
+"checksum libzfs 0.6.16 (git+https://github.com/whamcloud/rust-libzfs.git)" = "<none>"
+"checksum libzfs-sys 0.5.11 (git+https://github.com/whamcloud/rust-libzfs.git)" = "<none>"
+"checksum libzfs-types 0.1.2 (git+https://github.com/whamcloud/rust-libzfs.git)" = "<none>"
 "checksum linked-hash-map 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ae91b68aebc4ddb91978b11a1b02ddd8602a05ec19002801c5666000e05e0f83"
 "checksum lock_api 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f8912e782533a93a167888781b836336a6ca5da6175c05944c86cf28c31104dc"
 "checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"

--- a/device-scanner-daemon/Cargo.toml
+++ b/device-scanner-daemon/Cargo.toml
@@ -16,7 +16,7 @@ tracing-subscriber = "0.1"
 bytes = { version = "0.4", features = ["serde"] }
 im = { version = "13.0", features = ["serde"] }
 device-types = { path = "../device-types", version = "0.1.0" }
-libzfs-types = "0.1.1"
+libzfs-types = { git = "https://github.com/whamcloud/rust-libzfs.git", version = "0.1.2" }
 
 [dev-dependencies]
 insta = "0.12"

--- a/device-scanner-daemon/src/state.rs
+++ b/device-scanner-daemon/src/state.rs
@@ -19,7 +19,7 @@ use device_types::{
     uevent::UEvent,
     DevicePath,
 };
-use im::{hashset, ordset, vector, HashSet, OrdSet, Vector};
+use im::{ordset, vector, HashSet, OrdSet, Vector};
 
 /// Filter out any devices that are not suitable for mounting a filesystem.
 fn keep_usable(x: &UEvent) -> bool {
@@ -67,7 +67,7 @@ fn get_vgs(b: &Buckets, major: &str, minor: &str) -> Result<HashSet<Device>> {
                     .dm_vg_name
                     .clone()
                     .ok_or_else(|| error::none_error("Expected dm_vg_name"))?,
-                children: hashset![],
+                children: ordset![],
                 size: x
                     .dm_vg_size
                     .ok_or_else(|| error::none_error("Expected Size"))?,
@@ -109,7 +109,7 @@ fn get_partitions(
                 filesystem_type: x.fs_type.clone(),
                 fs_uuid: x.fs_uuid.clone(),
                 fs_label: x.fs_label.clone(),
-                children: hashset![],
+                children: ordset![],
                 mount: mount.map(ToOwned::to_owned),
             }))
         })
@@ -144,7 +144,7 @@ fn get_lvs(b: &Buckets, ys: &HashSet<Mount>, uuid: &str) -> Result<HashSet<Devic
                 filesystem_type: x.fs_type.clone(),
                 fs_uuid: x.fs_uuid.clone(),
                 fs_label: x.fs_label.clone(),
-                children: hashset![],
+                children: ordset![],
             }))
         })
         .collect()
@@ -167,7 +167,7 @@ fn get_scsis(b: &Buckets, ys: &HashSet<Mount>) -> Result<HashSet<Device>> {
                 fs_uuid: x.fs_uuid.clone(),
                 fs_label: x.fs_label.clone(),
                 paths: x.paths.clone(),
-                children: hashset![],
+                children: ordset![],
                 mount: mount.map(ToOwned::to_owned),
             }))
         })
@@ -200,7 +200,7 @@ fn get_mpaths(
                 filesystem_type: x.fs_type.clone(),
                 fs_uuid: x.fs_uuid.clone(),
                 fs_label: x.fs_label.clone(),
-                children: hashset![],
+                children: ordset![],
                 devpath: x.devpath.clone(),
                 mount: mount.map(ToOwned::to_owned),
             }))
@@ -228,7 +228,7 @@ fn get_mds(
                 major: x.major.clone(),
                 minor: x.minor.clone(),
                 size: x.size.ok_or_else(|| error::none_error("Expected size"))?,
-                children: hashset![],
+                children: ordset![],
                 uuid: x
                     .md_uuid
                     .clone()
@@ -262,7 +262,7 @@ fn get_pools(
                 state: x.state.clone(),
                 vdev: x.vdev.clone(),
                 size: x.size.parse()?,
-                children: hashset![],
+                children: ordset![],
             }))
         })
         .collect()

--- a/device-types/Cargo.toml
+++ b/device-types/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 
 [dependencies]
 serde = { version = "1", features = ["derive"] }
-libzfs-types = "0.1.1"
+libzfs-types = { git = "https://github.com/whamcloud/rust-libzfs.git", version = "0.1.2" }
 im = { version = "13.0", features = ["serde"] }
 log = "0.4"
 

--- a/device-types/src/devices.rs
+++ b/device-types/src/devices.rs
@@ -4,7 +4,6 @@
 
 use crate::{mount, DevicePath};
 use im::{ordset, OrdSet};
-use libzfs_types;
 use std::path::PathBuf;
 
 type Children = OrdSet<Device>;

--- a/device-types/src/devices.rs
+++ b/device-types/src/devices.rs
@@ -3,14 +3,16 @@
 // license that can be found in the LICENSE file.
 
 use crate::{mount, DevicePath};
-use im::{hashset, HashSet, OrdSet};
+use im::{ordset, OrdSet};
 use libzfs_types;
-use std::path::PathBuf;
+use std::{cmp::Ordering, path::PathBuf};
 
-type Children = HashSet<Device>;
+type Children = OrdSet<Device>;
 pub type Paths = OrdSet<DevicePath>;
 
-#[derive(Debug, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize, Clone)]
+#[derive(
+    Debug, PartialEq, Eq, PartialOrd, Ord, Hash, serde::Serialize, serde::Deserialize, Clone,
+)]
 pub struct Root {
     pub children: Children,
 }
@@ -18,12 +20,14 @@ pub struct Root {
 impl Default for Root {
     fn default() -> Self {
         Self {
-            children: hashset![],
+            children: ordset![],
         }
     }
 }
 
-#[derive(Debug, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize, Clone)]
+#[derive(
+    Debug, PartialEq, Eq, PartialOrd, Ord, Hash, serde::Serialize, serde::Deserialize, Clone,
+)]
 pub struct ScsiDevice {
     pub serial: Option<String>,
     pub scsi80: Option<String>,
@@ -39,7 +43,9 @@ pub struct ScsiDevice {
     pub children: Children,
 }
 
-#[derive(Debug, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize, Clone)]
+#[derive(
+    Debug, PartialEq, Eq, PartialOrd, Ord, Hash, serde::Serialize, serde::Deserialize, Clone,
+)]
 pub struct Partition {
     pub serial: Option<String>,
     pub scsi80: Option<String>,
@@ -56,7 +62,9 @@ pub struct Partition {
     pub children: Children,
 }
 
-#[derive(Debug, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize, Clone)]
+#[derive(
+    Debug, PartialEq, Eq, PartialOrd, Ord, Hash, serde::Serialize, serde::Deserialize, Clone,
+)]
 pub struct MdRaid {
     pub size: u64,
     pub major: String,
@@ -70,7 +78,9 @@ pub struct MdRaid {
     pub children: Children,
 }
 
-#[derive(Debug, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize, Clone)]
+#[derive(
+    Debug, PartialEq, Eq, PartialOrd, Ord, Hash, serde::Serialize, serde::Deserialize, Clone,
+)]
 pub struct Mpath {
     pub devpath: PathBuf,
     pub serial: Option<String>,
@@ -87,7 +97,9 @@ pub struct Mpath {
     pub mount: Option<mount::Mount>,
 }
 
-#[derive(Debug, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize, Clone)]
+#[derive(
+    Debug, PartialEq, Eq, PartialOrd, Ord, Hash, serde::Serialize, serde::Deserialize, Clone,
+)]
 pub struct VolumeGroup {
     pub name: String,
     pub uuid: String,
@@ -95,7 +107,9 @@ pub struct VolumeGroup {
     pub children: Children,
 }
 
-#[derive(Debug, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize, Clone)]
+#[derive(
+    Debug, PartialEq, Eq, PartialOrd, Ord, Hash, serde::Serialize, serde::Deserialize, Clone,
+)]
 pub struct LogicalVolume {
     pub name: String,
     pub uuid: String,
@@ -111,7 +125,9 @@ pub struct LogicalVolume {
     pub mount: Option<mount::Mount>,
 }
 
-#[derive(Debug, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize, Clone)]
+#[derive(
+    Debug, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize, Clone,
+)]
 pub struct Zpool {
     pub guid: u64,
     pub name: String,
@@ -124,7 +140,21 @@ pub struct Zpool {
     pub mount: Option<mount::Mount>,
 }
 
-#[derive(Debug, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize, Clone)]
+impl PartialOrd for Zpool {
+    fn partial_cmp(&self, other: &Zpool) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for Zpool {
+    fn cmp(&self, other: &Zpool) -> Ordering {
+        self.guid.cmp(&other.guid)
+    }
+}
+
+#[derive(
+    Debug, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize, Clone,
+)]
 pub struct Dataset {
     pub guid: u64,
     pub name: String,
@@ -133,7 +163,21 @@ pub struct Dataset {
     pub mount: Option<mount::Mount>,
 }
 
-#[derive(Debug, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize, Clone)]
+impl PartialOrd for Dataset {
+    fn partial_cmp(&self, other: &Dataset) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for Dataset {
+    fn cmp(&self, other: &Dataset) -> Ordering {
+        self.guid.cmp(&other.guid)
+    }
+}
+
+#[derive(
+    Debug, PartialEq, Eq, PartialOrd, Ord, Hash, serde::Serialize, serde::Deserialize, Clone,
+)]
 pub enum Device {
     Root(Root),
     ScsiDevice(ScsiDevice),

--- a/device-types/src/devices.rs
+++ b/device-types/src/devices.rs
@@ -5,7 +5,7 @@
 use crate::{mount, DevicePath};
 use im::{ordset, OrdSet};
 use libzfs_types;
-use std::{cmp::Ordering, path::PathBuf};
+use std::path::PathBuf;
 
 type Children = OrdSet<Device>;
 pub type Paths = OrdSet<DevicePath>;
@@ -126,7 +126,7 @@ pub struct LogicalVolume {
 }
 
 #[derive(
-    Debug, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize, Clone,
+    Debug, PartialEq, Eq, PartialOrd, Ord, Hash, serde::Serialize, serde::Deserialize, Clone,
 )]
 pub struct Zpool {
     pub guid: u64,
@@ -140,20 +140,8 @@ pub struct Zpool {
     pub mount: Option<mount::Mount>,
 }
 
-impl PartialOrd for Zpool {
-    fn partial_cmp(&self, other: &Zpool) -> Option<Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl Ord for Zpool {
-    fn cmp(&self, other: &Zpool) -> Ordering {
-        self.guid.cmp(&other.guid)
-    }
-}
-
 #[derive(
-    Debug, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize, Clone,
+    Debug, PartialEq, Eq, PartialOrd, Ord, Hash, serde::Serialize, serde::Deserialize, Clone,
 )]
 pub struct Dataset {
     pub guid: u64,
@@ -161,18 +149,6 @@ pub struct Dataset {
     pub kind: String,
     pub props: Vec<libzfs_types::ZProp>,
     pub mount: Option<mount::Mount>,
-}
-
-impl PartialOrd for Dataset {
-    fn partial_cmp(&self, other: &Dataset) -> Option<Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl Ord for Dataset {
-    fn cmp(&self, other: &Dataset) -> Ordering {
-        self.guid.cmp(&other.guid)
-    }
 }
 
 #[derive(

--- a/device-types/src/lib.rs
+++ b/device-types/src/lib.rs
@@ -164,18 +164,26 @@ pub mod mount {
     use crate::DevicePath;
     use std::path::PathBuf;
 
-    #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, serde::Serialize, serde::Deserialize)]
+    #[derive(
+        Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, serde::Serialize, serde::Deserialize,
+    )]
     #[serde(transparent)]
     pub struct MountPoint(pub PathBuf);
 
-    #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, serde::Serialize, serde::Deserialize)]
+    #[derive(
+        Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, serde::Serialize, serde::Deserialize,
+    )]
     #[serde(transparent)]
     pub struct FsType(pub String);
 
-    #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, serde::Serialize, serde::Deserialize)]
+    #[derive(
+        Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, serde::Serialize, serde::Deserialize,
+    )]
     pub struct MountOpts(pub String);
 
-    #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, serde::Serialize, serde::Deserialize, Clone)]
+    #[derive(
+        Debug, PartialEq, Eq, PartialOrd, Ord, Hash, serde::Serialize, serde::Deserialize, Clone,
+    )]
     pub struct Mount {
         pub source: DevicePath,
         pub target: MountPoint,

--- a/device-types/src/lib.rs
+++ b/device-types/src/lib.rs
@@ -164,18 +164,18 @@ pub mod mount {
     use crate::DevicePath;
     use std::path::PathBuf;
 
-    #[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+    #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, serde::Serialize, serde::Deserialize)]
     #[serde(transparent)]
     pub struct MountPoint(pub PathBuf);
 
-    #[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+    #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, serde::Serialize, serde::Deserialize)]
     #[serde(transparent)]
     pub struct FsType(pub String);
 
-    #[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+    #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, serde::Serialize, serde::Deserialize)]
     pub struct MountOpts(pub String);
 
-    #[derive(Debug, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize, Clone)]
+    #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, serde::Serialize, serde::Deserialize, Clone)]
     pub struct Mount {
         pub source: DevicePath,
         pub target: MountPoint,

--- a/zed-enhancer/Cargo.toml
+++ b/zed-enhancer/Cargo.toml
@@ -12,7 +12,7 @@ futures-preview = "0.3.0-alpha.19"
 derive_more = "0.15.0"
 serde_json = "1.0"
 device-types = { path = "../device-types", version = "0.1.0" }
-libzfs-types = "0.1.1"
-libzfs = "0.6.15"
+libzfs-types = { git = "https://github.com/whamcloud/rust-libzfs.git", version = "0.1.2" }
+libzfs = { git = "https://github.com/whamcloud/rust-libzfs.git", version = "0.6.16" }
 tracing = "0.1"
 tracing-subscriber = "0.1"


### PR DESCRIPTION
Avoid mis-calculation of equality of two `Device` enums. It is reported as not equal due to unspecified iteration order for `children`. This leads to emitting an update even though there's no real update.

Requires https://github.com/whamcloud/rust-libzfs/pull/90 to land first.

https://github.com/whamcloud/integrated-manager-for-lustre/issues/1833